### PR TITLE
Add arg to specify which display node qSlicerSpatialObjectWidget drives

### DIFF
--- a/SlicerModules/SpatialObjectsModule/Widgets/qSlicerSpatialObjectsModuleWidget.cxx
+++ b/SlicerModules/SpatialObjectsModule/Widgets/qSlicerSpatialObjectsModuleWidget.cxx
@@ -115,9 +115,9 @@ setSpatialObjectsNode(vtkMRMLSpatialObjectsNode* spatialObjectsNode)
 
   d->spatialObjectsNode = spatialObjectsNode;
 
-  d->LineDisplayWidget->setSpatialObjectsNode(spatialObjectsNode);
-  d->TubeDisplayWidget->setSpatialObjectsNode(spatialObjectsNode);
-  d->GlyphDisplayWidget->setSpatialObjectsNode(spatialObjectsNode);
+  d->LineDisplayWidget->setSpatialObjectsNode(spatialObjectsNode, 0);
+  d->TubeDisplayWidget->setSpatialObjectsNode(spatialObjectsNode, 1);
+  d->GlyphDisplayWidget->setSpatialObjectsNode(spatialObjectsNode, 2);
 
   emit currentNodeChanged(d->spatialObjectsNode);
 }

--- a/SlicerModules/SpatialObjectsModule/Widgets/qSlicerSpatialObjectsWidget.cxx
+++ b/SlicerModules/SpatialObjectsModule/Widgets/qSlicerSpatialObjectsWidget.cxx
@@ -182,14 +182,14 @@ SpatialObjectsDisplayPropertiesNode() const
 }
 
 //------------------------------------------------------------------------------
-void qSlicerSpatialObjectsWidget::setSpatialObjectsNode(vtkMRMLNode* node)
+void qSlicerSpatialObjectsWidget::setSpatialObjectsNode(vtkMRMLNode* node, int DisplayNodeIndex)
 {
-  this->setSpatialObjectsNode(vtkMRMLSpatialObjectsNode::SafeDownCast(node));
+  this->setSpatialObjectsNode(vtkMRMLSpatialObjectsNode::SafeDownCast(node), DisplayNodeIndex);
 }
 
 //------------------------------------------------------------------------------
 void qSlicerSpatialObjectsWidget::
-setSpatialObjectsNode(vtkMRMLSpatialObjectsNode* SpatialObjectsNode)
+setSpatialObjectsNode(vtkMRMLSpatialObjectsNode* SpatialObjectsNode, int DisplayNodeIndex)
 {
   Q_D(qSlicerSpatialObjectsWidget);
 
@@ -197,7 +197,7 @@ setSpatialObjectsNode(vtkMRMLSpatialObjectsNode* SpatialObjectsNode)
   d->SpatialObjectsNode = SpatialObjectsNode;
 
   this->setSpatialObjectsDisplayNode(
-    d->SpatialObjectsNode ? d->SpatialObjectsNode->GetDisplayNode() : NULL);
+    d->SpatialObjectsNode ? d->SpatialObjectsNode->GetNthDisplayNode(DisplayNodeIndex) : NULL);
 
   qvtkReconnect(oldNode, this->SpatialObjectsNode(),
                 vtkCommand::ModifiedEvent, this,
@@ -604,7 +604,7 @@ void qSlicerSpatialObjectsWidget::updateWidgetFromMRML()
     d->SpatialObjectsDisplayNode->GetVisibility());
   d->OpacitySlider->setValue(d->SpatialObjectsDisplayNode->GetOpacity());
 
-  d->ColorByScalarsColorTableComboBox->setCurrentNode
+  d->ColorByScalarsColorTableComboBox->setCurrentNodeID
     (d->SpatialObjectsDisplayNode->GetColorNodeID());
   d->ColorByScalarComboBox->setDataSet(
     vtkDataSet::SafeDownCast(d->SpatialObjectsNode->GetPolyData()));

--- a/SlicerModules/SpatialObjectsModule/Widgets/qSlicerSpatialObjectsWidget.h
+++ b/SlicerModules/SpatialObjectsModule/Widgets/qSlicerSpatialObjectsWidget.h
@@ -67,8 +67,8 @@ public:
     SpatialObjectsDisplayPropertiesNode() const;
 
 public slots:
-  void setSpatialObjectsNode(vtkMRMLNode *node);
-  void setSpatialObjectsNode(vtkMRMLSpatialObjectsNode *node);
+  void setSpatialObjectsNode(vtkMRMLNode *node, int DisplayNodeIndex = 0);
+  void setSpatialObjectsNode(vtkMRMLSpatialObjectsNode* SpatialObjectsNode, int DisplayNodeIndex = 0);
 
   void setVisibility(bool);
   void setColorByScalar();


### PR DESCRIPTION
Before, the function setSpatialObjectDisplay() associated
the first display node of the passed node.
Now we can choose which display node it should be associated with.