### PR TITLE
Replace ITKv3 compatibility functions by ITKv4 functions

### DIFF
--- a/Base/Registration/itkBSplineImageToImageRegistrationMethod.txx
+++ b/Base/Registration/itkBSplineImageToImageRegistrationMethod.txx
@@ -843,7 +843,7 @@ BSplineImageToImageRegistrationMethod<TImage>
       std::string name;
       ss << "inCoeImage" << k << ".mha";
       ss >> name;
-      writer->SetInput( this->GetTypedTransform()->GetCoefficientImage()[k] );
+      writer->SetInput( this->GetTypedTransform()->GetCoefficientImages()[k] );
       writer->SetFileName( name );
       try
         {
@@ -857,7 +857,7 @@ BSplineImageToImageRegistrationMethod<TImage>
     */
 
     upsampler->SetInput( this->GetTypedTransform()
-                         ->GetCoefficientImage()[k] );
+                         ->GetCoefficientImages()[k] );
     upsampler->SetInterpolator( function );
     upsampler->SetTransform( identity );
     upsampler->SetSize( gridSize );

--- a/Base/Registration/itkImageToImageRegistrationHelper.txx
+++ b/Base/Registration/itkImageToImageRegistrationHelper.txx
@@ -23,7 +23,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkResampleImageFilter.h"
-#include "itkDifferenceImageFilter.h"
+#include "itkTestingComparisonImageFilter.h"
 #include "itkInterpolateImageFunction.h"
 #include "itkNearestNeighborInterpolateImageFunction.h"
 #include "itkLinearInterpolateImageFunction.h"
@@ -1056,7 +1056,7 @@ ImageToImageRegistrationHelper<TImage>
     return;
     }
 
-  typedef DifferenceImageFilter<TImage, TImage> DifferenceFilterType;
+  typedef Testing::ComparisonImageFilter<TImage, TImage> DifferenceFilterType;
 
   typename TImage::ConstPointer imTemp = this->GetFixedImage();
   this->SetFixedImage( this->m_BaselineImage );


### PR DESCRIPTION
This was forgotten in commit 1e0d898, because it was
tested on TubeTK standalone and not on TubeTK with Slicer