### PR TITLE
ENH: Update BlockSetOSCXVars from Slicer, TubeMathTest, Style

### DIFF
--- a/Applications/ComputeRegionSignatures/ComputeRegionSignatures.cxx
+++ b/Applications/ComputeRegionSignatures/ComputeRegionSignatures.cxx
@@ -24,7 +24,6 @@ limitations under the License.
 #include "tubeMessage.h"
 
 #include <itkDanielssonDistanceMapImageFilter.h>
-#include <itkImageToVectorImageFilter.h>
 #include <itkImageFileReader.h>
 #include <itkImageFileWriter.h>
 

--- a/Base/Numerics/Testing/tubeTubeMathTest.cxx
+++ b/Base/Numerics/Testing/tubeTubeMathTest.cxx
@@ -81,31 +81,37 @@ int tubeTubeMathTest( int tubeNotUsed( argc ),
     double rndX = rndGen->GetNormalVariate( 0, 1 );
     double rndY = rndGen->GetNormalVariate( 0, 1 );
     double rndZ = rndGen->GetNormalVariate( 0, 1 );
-    std::cout << "      " << rndX << ", " << rndY << ", " << rndZ
-      << std::endl;
     x += rndX;
     y += rndY;
     z += rndZ;
     point.SetPosition( x, y, z );
     pointList.push_back( point );
-    std::cout << i << " : " << x << ", " << y << ", " << z << std::endl;
     }
 
   std::cout << "Tangents and normals..." << std::endl;
   tube->SetPoints( pointList );
   ::tube::ComputeTubeTangentsAndNormals< TubeType >( tube );
 
-  std::cout << "Smoothing..." << std::endl;
-  TubeType::Pointer tube2 = ::tube::SmoothTube< TubeType >( tube, 2,
-    ::tube::SMOOTH_TUBE_USING_INDEX_AVERAGE );
-
   double tLength = tubeLength( tube );
-  double t2Length = tubeLength( tube2 );
-  if( tLength <= t2Length )
+  std::cout << "Length = " << tLength << std::endl;
+
+  for( unsigned int i = 0; i < 20; ++i )
     {
-    std::cout << "ERROR: Raw length = " << tLength << " <= Smooth length = "
-      << t2Length << std::endl;
-    returnStatus = EXIT_FAILURE;
+    std::cout << "Smoothing..." << std::endl;
+    TubeType::Pointer tube2 = ::tube::SmoothTube< TubeType >( tube, 2,
+      ::tube::SMOOTH_TUBE_USING_INDEX_AVERAGE );
+
+    double t2Length = tubeLength( tube2 );
+    std::cout << "Length = " << t2Length << std::endl;
+    if( tLength <= t2Length )
+      {
+      std::cout << "ERROR: Raw length = " << tLength
+        << " <= Smooth length = " << t2Length << std::endl;
+      returnStatus = EXIT_FAILURE;
+      }
+
+    tube = tube2;
+    tLength = t2Length;
     }
 
   return returnStatus;

--- a/Base/Registration/itkAnisotropicSimilarity3DTransform.h
+++ b/Base/Registration/itkAnisotropicSimilarity3DTransform.h
@@ -1,12 +1,12 @@
 /*=========================================================================
 
   Program:   Insight Segmentation & Registration Toolkit
-  Module:    $RCSfile: itkAnisotropicSimilarity3DTransform.h,v $
+  Module:    $RCSfile: ITKHeader.h,v $
   Language:  C++
-  Date:      $Date: 2006/08/09 04:35:32 $
-  Version:   $Revision: 1.3 $
+  Date:      $Date: 2007-07-10 11:35:36 -0400 (Tue, 10 Jul 2007) $
+  Version:   $Revision: 0 $
 
-  Copyright (c) Insight Software Consortium. All rights reserved.
+  Copyright (c) 2002 Insight Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
      This software is distributed WITHOUT ANY WARRANTY; without even
@@ -14,7 +14,6 @@
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
-
 #ifndef __itkAnisotropicSimilarity3DTransform_h
 #define __itkAnisotropicSimilarity3DTransform_h
 
@@ -81,10 +80,11 @@ public:
   typedef typename Superclass::OutputVectorType    OutputVectorType;
   typedef typename Superclass::InputVnlVectorType  InputVnlVectorType;
   typedef typename Superclass::OutputVnlVectorType OutputVnlVectorType;
+
   typedef typename Superclass::InputCovariantVectorType
-  InputCovariantVectorType;
+                                                 InputCovariantVectorType;
   typedef typename Superclass::OutputCovariantVectorType
-  OutputCovariantVectorType;
+                                                 OutputCovariantVectorType;
   typedef typename Superclass::MatrixType        MatrixType;
   typedef typename Superclass::InverseMatrixType InverseMatrixType;
   typedef typename Superclass::CenterType        CenterType;
@@ -103,7 +103,8 @@ public:
    * to within a specified tolerance, else an exception is thrown.
    *
    * \sa MatrixOffsetTransformBase::SetMatrix() */
-  virtual void SetMatrix(const MatrixType & matrix);
+  virtual void SetMatrix( const MatrixType & matrix );
+  virtual void SetMatrix( const MatrixType & matrix, double tolerance );
 
   /** Set the transformation from a container of parameters This is typically
    * used by optimizers.  There are 7 parameters. The first three represent the
@@ -126,15 +127,17 @@ public:
    * transform is invertible at this point. */
   virtual const JacobianType & GetJacobian(const InputPointType  & point ) const;
 
-  virtual void ComputeJacobianWithRespectToParameters(const InputPointType & p, JacobianType & jacobian) const;
+  virtual void ComputeJacobianWithRespectToParameters(
+    const InputPointType & p, JacobianType & jacobian) const;
 
 protected:
-  AnisotropicSimilarity3DTransform(const MatrixType & matrix, const OutputVectorType & offset);
+  AnisotropicSimilarity3DTransform(const MatrixType & matrix,
+    const OutputVectorType & offset);
   AnisotropicSimilarity3DTransform(unsigned int paramDim);
   AnisotropicSimilarity3DTransform();
   ~AnisotropicSimilarity3DTransform()
-  {
-  };
+    {
+    };
 
   void PrintSelf(std::ostream & os, Indent indent) const;
 

--- a/Base/Registration/itkAnisotropicSimilarity3DTransform.txx
+++ b/Base/Registration/itkAnisotropicSimilarity3DTransform.txx
@@ -1,12 +1,12 @@
 /*=========================================================================
 
   Program:   Insight Segmentation & Registration Toolkit
-  Module:    $RCSfile: itkAnisotropicSimilarity3DTransform.txx,v $
+  Module:    $RCSfile: ITKHeader.h,v $
   Language:  C++
-  Date:      $Date: 2007/11/27 16:04:48 $
-  Version:   $Revision: 1.9 $
+  Date:      $Date: 2007-07-10 11:35:36 -0400 (Tue, 10 Jul 2007) $
+  Version:   $Revision: 0 $
 
-  Copyright (c) Insight Software Consortium. All rights reserved.
+  Copyright (c) 2002 Insight Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
      This software is distributed WITHOUT ANY WARRANTY; without even
@@ -14,8 +14,8 @@
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
-#ifndef _itkAnisotropicSimilarity3DTransform_txx
-#define _itkAnisotropicSimilarity3DTransform_txx
+#ifndef __itkAnisotropicSimilarity3DTransform_txx
+#define __itkAnisotropicSimilarity3DTransform_txx
 
 #include "itkAnisotropicSimilarity3DTransform.h"
 #include "vnl/vnl_math.h"
@@ -37,15 +37,17 @@ AnisotropicSimilarity3DTransform<TScalarType>
 
 // Constructor with arguments
 template <class TScalarType>
-AnisotropicSimilarity3DTransform<TScalarType>::AnisotropicSimilarity3DTransform(unsigned int paramDim) :
+AnisotropicSimilarity3DTransform<TScalarType>
+::AnisotropicSimilarity3DTransform(unsigned int paramDim) :
   Superclass(paramDim)
 {
 }
 
 // Constructor with arguments
 template <class TScalarType>
-AnisotropicSimilarity3DTransform<TScalarType>::AnisotropicSimilarity3DTransform( const MatrixType & matrix,
-                                                                                 const OutputVectorType & offset) :
+AnisotropicSimilarity3DTransform<TScalarType>
+::AnisotropicSimilarity3DTransform( const MatrixType & matrix,
+  const OutputVectorType & offset) :
   Superclass(matrix, offset)
 {
 }
@@ -80,6 +82,16 @@ void
 AnisotropicSimilarity3DTransform<TScalarType>
 ::SetMatrix( const MatrixType & matrix )
 {
+  const double tolerance = 1e-10;
+  this->SetMatrix( matrix, tolerance );
+}
+
+// Directly set the matrix
+template <class TScalarType>
+void
+AnisotropicSimilarity3DTransform<TScalarType>
+::SetMatrix( const MatrixType & matrix, double tolerance )
+{
   //
   // Since the matrix should be an orthogonal matrix
   // multiplied by the scale factor, then its determinant
@@ -111,10 +123,11 @@ AnisotropicSimilarity3DTransform<TScalarType>
 
   MatrixType testForOrthogonal = matrix * scaleMatrix;
 
-  const double tolerance = 1e-10;
   if( !this->MatrixIsOrthogonal( testForOrthogonal, tolerance ) )
     {
-    itkExceptionMacro( << "Attempting to set a non-orthogonal matrix (after removing scaling)" );
+    itkExceptionMacro(
+      << "Attempting to set non-orthogonal matrix (after removing scaling)"
+      );
     }
 
   typedef MatrixOffsetTransformBase<TScalarType, 3> Baseclass;
@@ -189,7 +202,7 @@ template <class TScalarType>
 const typename AnisotropicSimilarity3DTransform<TScalarType>::ParametersType
 & AnisotropicSimilarity3DTransform<TScalarType>
 ::GetParameters( void ) const
-  {
+{
   itkDebugMacro( << "Getting parameters ");
 
   this->m_Parameters[0] = this->GetVersor().GetX();
@@ -208,21 +221,24 @@ const typename AnisotropicSimilarity3DTransform<TScalarType>::ParametersType
   itkDebugMacro(<< "After getting parameters " << this->m_Parameters );
 
   return this->m_Parameters;
-  }
+}
 
 // Set parameters
 template <class TScalarType>
 const typename AnisotropicSimilarity3DTransform<TScalarType>::JacobianType
 & AnisotropicSimilarity3DTransform<TScalarType>::
 GetJacobian( const InputPointType &p ) const
-  {
-  ComputeJacobianWithRespectToParameters( p, this->m_NonThreadsafeSharedJacobian );
+{
+  ComputeJacobianWithRespectToParameters( p,
+    this->m_NonThreadsafeSharedJacobian );
   return this->m_NonThreadsafeSharedJacobian;
-  }
+}
+
 template <class TScalarType>
 void
-AnisotropicSimilarity3DTransform<TScalarType>::ComputeJacobianWithRespectToParameters(const InputPointType & p,
-                                                                                      JacobianType & jacobian) const
+AnisotropicSimilarity3DTransform<TScalarType>
+::ComputeJacobianWithRespectToParameters(const InputPointType & p,
+  JacobianType & jacobian) const
 {
   typedef typename VersorType::ValueType ValueType;
 
@@ -326,15 +342,18 @@ AnisotropicSimilarity3DTransform<TScalarType>
 {
   MatrixType matrix = this->GetMatrix();
 
-  m_Scale[0] = sqrt( fabs( matrix.GetVnlMatrix()[0][0] * matrix.GetVnlMatrix()[0][0]
-                           + matrix.GetVnlMatrix()[0][1] * matrix.GetVnlMatrix()[0][1]
-                           + matrix.GetVnlMatrix()[0][2] * matrix.GetVnlMatrix()[0][2] ) );
-  m_Scale[1] = sqrt( fabs( matrix.GetVnlMatrix()[1][0] * matrix.GetVnlMatrix()[1][0]
-                           + matrix.GetVnlMatrix()[1][1] * matrix.GetVnlMatrix()[1][1]
-                           + matrix.GetVnlMatrix()[1][2] * matrix.GetVnlMatrix()[1][2] ) );
-  m_Scale[2] = sqrt( fabs( matrix.GetVnlMatrix()[2][0] * matrix.GetVnlMatrix()[2][0]
-                           + matrix.GetVnlMatrix()[2][1] * matrix.GetVnlMatrix()[2][1]
-                           + matrix.GetVnlMatrix()[2][2] * matrix.GetVnlMatrix()[2][2] ) );
+  m_Scale[0] = sqrt( fabs( matrix.GetVnlMatrix()[0][0] *
+    matrix.GetVnlMatrix()[0][0]
+    + matrix.GetVnlMatrix()[0][1] * matrix.GetVnlMatrix()[0][1]
+    + matrix.GetVnlMatrix()[0][2] * matrix.GetVnlMatrix()[0][2] ) );
+  m_Scale[1] = sqrt( fabs( matrix.GetVnlMatrix()[1][0] *
+    matrix.GetVnlMatrix()[1][0]
+    + matrix.GetVnlMatrix()[1][1] * matrix.GetVnlMatrix()[1][1]
+    + matrix.GetVnlMatrix()[1][2] * matrix.GetVnlMatrix()[1][2] ) );
+  m_Scale[2] = sqrt( fabs( matrix.GetVnlMatrix()[2][0] *
+    matrix.GetVnlMatrix()[2][0]
+    + matrix.GetVnlMatrix()[2][1] * matrix.GetVnlMatrix()[2][1]
+    + matrix.GetVnlMatrix()[2][2] * matrix.GetVnlMatrix()[2][2] ) );
 
   MatrixType scaleMatrix;
   scaleMatrix(0, 0) = m_Scale[0];
@@ -352,7 +371,8 @@ AnisotropicSimilarity3DTransform<TScalarType>
 // Print self
 template <class TScalarType>
 void
-AnisotropicSimilarity3DTransform<TScalarType>::PrintSelf(std::ostream & os, Indent indent) const
+AnisotropicSimilarity3DTransform<TScalarType>::PrintSelf(
+  std::ostream & os, Indent indent ) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Scale = " << m_Scale << std::endl;

--- a/Base/Registration/itkImageToImageRegistrationHelper.txx
+++ b/Base/Registration/itkImageToImageRegistrationHelper.txx
@@ -1,12 +1,12 @@
 /*=========================================================================
 
   Program:   Insight Segmentation & Registration Toolkit
-  Module:    $RCSfile: MomentRegistrator.txx,v $
+  Module:    $RCSfile: ITKHeader.h,v $
   Language:  C++
-  Date:      $Date: 2007/03/29 17:52:55 $
-  Version:   $Revision: 1.6 $
+  Date:      $Date: 2007-07-10 11:35:36 -0400 (Tue, 10 Jul 2007) $
+  Version:   $Revision: 0 $
 
-  Copyright (c) Insight Software Consortium. All rights reserved.
+  Copyright (c) 2002 Insight Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
      This software is distributed WITHOUT ANY WARRANTY; without even
@@ -14,9 +14,8 @@
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
-
-#ifndef __ImageToImageRegistrationHelper_txx
-#define __ImageToImageRegistrationHelper_txx
+#ifndef __itkImageToImageRegistrationHelper_txx
+#define __itkImageToImageRegistrationHelper_txx
 
 #include "itkImageToImageRegistrationHelper.h"
 
@@ -119,8 +118,10 @@ ImageToImageRegistrationHelper<TImage>
   m_RigidTargetError = 0.0001;
   m_RigidMaxIterations = 100;
   m_RigidTransform = NULL;
-  m_RigidMetricMethodEnum = OptimizedRegistrationMethodType::MATTES_MI_METRIC;
-  m_RigidInterpolationMethodEnum = OptimizedRegistrationMethodType::LINEAR_INTERPOLATION;
+  m_RigidMetricMethodEnum =
+    OptimizedRegistrationMethodType::MATTES_MI_METRIC;
+  m_RigidInterpolationMethodEnum =
+    OptimizedRegistrationMethodType::LINEAR_INTERPOLATION;
   m_RigidMetricValue = 0.0;
 
   // Affine
@@ -128,8 +129,10 @@ ImageToImageRegistrationHelper<TImage>
   m_AffineTargetError = 0.0001;
   m_AffineMaxIterations = 50;
   m_AffineTransform = NULL;
-  m_AffineMetricMethodEnum = OptimizedRegistrationMethodType::MATTES_MI_METRIC;
-  m_AffineInterpolationMethodEnum = OptimizedRegistrationMethodType::LINEAR_INTERPOLATION;
+  m_AffineMetricMethodEnum =
+    OptimizedRegistrationMethodType::MATTES_MI_METRIC;
+  m_AffineInterpolationMethodEnum =
+    OptimizedRegistrationMethodType::LINEAR_INTERPOLATION;
   m_AffineMetricValue = 0.0;
 
   // BSpline
@@ -138,8 +141,10 @@ ImageToImageRegistrationHelper<TImage>
   m_BSplineMaxIterations = 20;
   m_BSplineControlPointPixelSpacing = 40;
   m_BSplineTransform = NULL;
-  m_BSplineMetricMethodEnum = OptimizedRegistrationMethodType::MATTES_MI_METRIC;
-  m_BSplineInterpolationMethodEnum = OptimizedRegistrationMethodType::BSPLINE_INTERPOLATION;
+  m_BSplineMetricMethodEnum =
+    OptimizedRegistrationMethodType::MATTES_MI_METRIC;
+  m_BSplineInterpolationMethodEnum =
+    OptimizedRegistrationMethodType::BSPLINE_INTERPOLATION;
   m_BSplineMetricValue = 0.0;
 
 }
@@ -464,14 +469,14 @@ ImageToImageRegistrationHelper<TImage>
       PixelType fixedImageMax = calc->GetMaximum();
       PixelType fixedImageMin = calc->GetMinimum();
 
-      regRigid->SetFixedImageSamplesIntensityThreshold( static_cast<PixelType>(
-                                                          ( m_SampleIntensityPortion
-                                                            * (fixedImageMax - fixedImageMin) )
-                                                          + fixedImageMin ) );
+      regRigid->SetFixedImageSamplesIntensityThreshold(
+        static_cast<PixelType>( ( m_SampleIntensityPortion *
+        (fixedImageMax - fixedImageMin) ) + fixedImageMin ) );
       }
     if( m_UseRegionOfInterest )
       {
-      regRigid->SetRegionOfInterest( m_RegionOfInterestPoint1, m_RegionOfInterestPoint2 );
+      regRigid->SetRegionOfInterest( m_RegionOfInterestPoint1,
+        m_RegionOfInterestPoint2 );
       }
     regRigid->SetSampleFromOverlap( m_SampleFromOverlap );
     regRigid->SetMetricMethodEnum( m_RigidMetricMethodEnum );
@@ -481,8 +486,10 @@ ImageToImageRegistrationHelper<TImage>
       {
       scales.set_size( 3 );
       scales[0] = 1.0 / m_ExpectedRotationMagnitude;
-      scales[1] = 1.0 / (m_ExpectedOffsetPixelMagnitude * m_FixedImage->GetSpacing()[0]);
-      scales[2] = 1.0 / (m_ExpectedOffsetPixelMagnitude * m_FixedImage->GetSpacing()[0]);
+      scales[1] = 1.0 / ( m_ExpectedOffsetPixelMagnitude *
+        m_FixedImage->GetSpacing()[0]);
+      scales[2] = 1.0 / ( m_ExpectedOffsetPixelMagnitude *
+        m_FixedImage->GetSpacing()[0]);
       }
     else if( ImageDimension == 3 )
       {
@@ -490,15 +497,18 @@ ImageToImageRegistrationHelper<TImage>
       scales[0] = 1.0 / m_ExpectedRotationMagnitude;
       scales[1] = 1.0 / m_ExpectedRotationMagnitude;
       scales[2] = 1.0 / m_ExpectedRotationMagnitude;
-      scales[3] = 1.0 / (m_ExpectedOffsetPixelMagnitude * m_FixedImage->GetSpacing()[0]);
-      scales[4] = 1.0 / (m_ExpectedOffsetPixelMagnitude * m_FixedImage->GetSpacing()[0]);
-      scales[5] = 1.0 / (m_ExpectedOffsetPixelMagnitude * m_FixedImage->GetSpacing()[0]);
+      scales[3] = 1.0 / ( m_ExpectedOffsetPixelMagnitude *
+        m_FixedImage->GetSpacing()[0]);
+      scales[4] = 1.0 / ( m_ExpectedOffsetPixelMagnitude *
+        m_FixedImage->GetSpacing()[0]);
+      scales[5] = 1.0 / ( m_ExpectedOffsetPixelMagnitude *
+        m_FixedImage->GetSpacing()[0]);
       }
     else
       {
       std::cerr
-      << "ERROR: Only 2 and 3 dimensional images are supported due to rigid registration transforms limitations."
-      << std::endl;
+        << "ERROR: Only 2 and 3 dimensional images are supported."
+        << std::endl;
       }
     /*
     double minS = scales[0];
@@ -520,21 +530,28 @@ ImageToImageRegistrationHelper<TImage>
 
     if( m_CurrentMatrixTransform.IsNotNull() )
       {
-      regRigid->GetTypedTransform()->SetCenter( m_CurrentMatrixTransform->GetCenter() );
-      regRigid->GetTypedTransform()->SetMatrix( m_CurrentMatrixTransform->GetMatrix() );
-      regRigid->GetTypedTransform()->SetOffset( m_CurrentMatrixTransform->GetOffset() );
-      regRigid->SetInitialTransformParameters( regRigid->GetTypedTransform()->GetParameters() );
-      regRigid->SetInitialTransformFixedParameters( regRigid->GetTypedTransform()->GetFixedParameters() );
+      regRigid->GetTypedTransform()->SetCenter(
+        m_CurrentMatrixTransform->GetCenter() );
+      regRigid->GetTypedTransform()->SetMatrix(
+        m_CurrentMatrixTransform->GetMatrix() );
+      regRigid->GetTypedTransform()->SetOffset(
+        m_CurrentMatrixTransform->GetOffset() );
+      regRigid->SetInitialTransformParameters(
+        regRigid->GetTypedTransform()->GetParameters() );
+      regRigid->SetInitialTransformFixedParameters(
+        regRigid->GetTypedTransform()->GetFixedParameters() );
       }
 
     regRigid->Update();
 
     m_RigidTransform = RigidTransformType::New();
-    m_RigidTransform->SetFixedParameters(regRigid->GetTypedTransform()->GetFixedParameters() );
+    m_RigidTransform->SetFixedParameters(
+      regRigid->GetTypedTransform()->GetFixedParameters() );
     // must call GetAffineTransform here because the typed transform
     // is a versor and has only 6 parameters (in this code the type
     // RigidTransform is a 12 parameter transform)
-    m_RigidTransform->SetParametersByValue(regRigid->GetAffineTransform()->GetParameters() );
+    m_RigidTransform->SetParametersByValue(
+      regRigid->GetAffineTransform()->GetParameters() );
     m_CurrentMatrixTransform = regRigid->GetAffineTransform();
     m_CurrentBSplineTransform = 0;
 
@@ -552,15 +569,18 @@ ImageToImageRegistrationHelper<TImage>
       std::cout << "*** AFFINE REGISTRATION ***" << std::endl;
       }
 
-    typename AffineRegistrationMethodType::Pointer regAff = AffineRegistrationMethodType::New();
+    typename AffineRegistrationMethodType::Pointer regAff =
+      AffineRegistrationMethodType::New();
     regAff->SetRandomNumberSeed( m_RandomNumberSeed );
     regAff->SetReportProgress( m_ReportProgress );
     regAff->SetMovingImage( m_CurrentMovingImage );
     regAff->SetFixedImage( m_FixedImage );
-    regAff->SetNumberOfSamples( (unsigned int)(m_AffineSamplingRatio * fixedImageNumPixels) );
+    regAff->SetNumberOfSamples( (unsigned int)(m_AffineSamplingRatio
+      * fixedImageNumPixels) );
     if( m_UseRegionOfInterest )
       {
-      regAff->SetRegionOfInterest( m_RegionOfInterestPoint1, m_RegionOfInterestPoint2 );
+      regAff->SetRegionOfInterest( m_RegionOfInterestPoint1,
+        m_RegionOfInterestPoint2 );
       }
     regAff->SetSampleFromOverlap( m_SampleFromOverlap );
     regAff->SetMinimizeMemory( m_MinimizeMemory );
@@ -594,10 +614,9 @@ ImageToImageRegistrationHelper<TImage>
       PixelType fixedImageMax = calc->GetMaximum();
       PixelType fixedImageMin = calc->GetMinimum();
 
-      regAff->SetFixedImageSamplesIntensityThreshold( static_cast<PixelType>(
-                                                        ( m_SampleIntensityPortion
-                                                          * (fixedImageMax - fixedImageMin) )
-                                                        + fixedImageMin ) );
+      regAff->SetFixedImageSamplesIntensityThreshold(
+        static_cast<PixelType>( ( m_SampleIntensityPortion
+          * (fixedImageMax - fixedImageMin) ) + fixedImageMin ) );
       }
     regAff->SetMetricMethodEnum( m_AffineMetricMethodEnum );
     regAff->SetInterpolationMethodEnum( m_AffineInterpolationMethodEnum );
@@ -610,18 +629,21 @@ ImageToImageRegistrationHelper<TImage>
         {
         if( d1 == d2 )
           {
-          scales[scaleNum] = 1.0 / (m_ExpectedRotationMagnitude + m_ExpectedScaleMagnitude);
+          scales[scaleNum] = 1.0 / (
+            m_ExpectedRotationMagnitude + m_ExpectedScaleMagnitude);
           }
         else
           {
-          scales[scaleNum] = 1.0 / (m_ExpectedRotationMagnitude + m_ExpectedSkewMagnitude);
+          scales[scaleNum] = 1.0 / (
+            m_ExpectedRotationMagnitude + m_ExpectedSkewMagnitude);
           }
         ++scaleNum;
         }
       }
     for( int d1 = 0; d1 < ImageDimension; d1++ )
       {
-      scales[scaleNum] = 1.0 / (m_ExpectedOffsetPixelMagnitude * m_FixedImage->GetSpacing()[0]);
+      scales[scaleNum] = 1.0 / (
+        m_ExpectedOffsetPixelMagnitude * m_FixedImage->GetSpacing()[0]);
       ++scaleNum;
       }
     /*
@@ -644,11 +666,16 @@ ImageToImageRegistrationHelper<TImage>
 
     if( m_CurrentMatrixTransform.IsNotNull() )
       {
-      regAff->GetTypedTransform()->SetCenter( m_CurrentMatrixTransform->GetCenter() );
-      regAff->GetTypedTransform()->SetMatrix( m_CurrentMatrixTransform->GetMatrix() );
-      regAff->GetTypedTransform()->SetOffset( m_CurrentMatrixTransform->GetOffset() );
-      regAff->SetInitialTransformParameters( regAff->GetTypedTransform()->GetParameters() );
-      regAff->SetInitialTransformFixedParameters( regAff->GetTypedTransform()->GetFixedParameters() );
+      regAff->GetTypedTransform()->SetCenter(
+        m_CurrentMatrixTransform->GetCenter() );
+      regAff->GetTypedTransform()->SetMatrix(
+        m_CurrentMatrixTransform->GetMatrix() );
+      regAff->GetTypedTransform()->SetOffset(
+        m_CurrentMatrixTransform->GetOffset() );
+      regAff->SetInitialTransformParameters(
+        regAff->GetTypedTransform()->GetParameters() );
+      regAff->SetInitialTransformFixedParameters(
+        regAff->GetTypedTransform()->GetFixedParameters() );
       }
 
     regAff->Update();
@@ -677,15 +704,18 @@ ImageToImageRegistrationHelper<TImage>
       m_CompletedResampling = true;
       }
 
-    typename BSplineRegistrationMethodType::Pointer regBspline = BSplineRegistrationMethodType::New();
+    typename BSplineRegistrationMethodType::Pointer regBspline =
+      BSplineRegistrationMethodType::New();
     regBspline->SetRandomNumberSeed( m_RandomNumberSeed );
     regBspline->SetReportProgress( m_ReportProgress );
     regBspline->SetFixedImage( m_FixedImage );
     regBspline->SetMovingImage( m_CurrentMovingImage );
-    regBspline->SetNumberOfSamples( (unsigned int)(m_BSplineSamplingRatio * fixedImageNumPixels) );
+    regBspline->SetNumberOfSamples( (unsigned int)(
+        m_BSplineSamplingRatio * fixedImageNumPixels) );
     if( m_UseRegionOfInterest )
       {
-      regBspline->SetRegionOfInterest( m_RegionOfInterestPoint1, m_RegionOfInterestPoint2 );
+      regBspline->SetRegionOfInterest( m_RegionOfInterestPoint1,
+        m_RegionOfInterestPoint2 );
       }
     regBspline->SetSampleFromOverlap( m_SampleFromOverlap );
     regBspline->SetMinimizeMemory( m_MinimizeMemory );
@@ -714,14 +744,15 @@ ImageToImageRegistrationHelper<TImage>
       PixelType fixedImageMax = calc->GetMaximum();
       PixelType fixedImageMin = calc->GetMinimum();
 
-      regBspline->SetFixedImageSamplesIntensityThreshold( static_cast<PixelType>(
-                                                            ( m_SampleIntensityPortion
-                                                              * (fixedImageMax - fixedImageMin) )
-                                                            + fixedImageMin ) );
+      regBspline->SetFixedImageSamplesIntensityThreshold(
+        static_cast<PixelType>( ( m_SampleIntensityPortion
+        * (fixedImageMax - fixedImageMin) ) + fixedImageMin ) );
       }
     regBspline->SetMetricMethodEnum( m_BSplineMetricMethodEnum );
-    regBspline->SetInterpolationMethodEnum( m_BSplineInterpolationMethodEnum );
-    regBspline->SetNumberOfControlPoints( (int)(fixedImageSize[0] / m_BSplineControlPointPixelSpacing) );
+    regBspline->SetInterpolationMethodEnum(
+      m_BSplineInterpolationMethodEnum );
+    regBspline->SetNumberOfControlPoints( (int)(fixedImageSize[0] /
+      m_BSplineControlPointPixelSpacing) );
 
     regBspline->Update();
 
@@ -751,21 +782,20 @@ ImageToImageRegistrationHelper<TImage>
                  const BSplineTransformType * bsplineTransform,
                  PixelType defaultPixelValue)
 {
-  typedef InterpolateImageFunction<TImage, double> InterpolatorType;
+  typedef InterpolateImageFunction<TImage, double>
+    InterpolatorType;
   typedef NearestNeighborInterpolateImageFunction<TImage, double>
-  NearestNeighborInterpolatorType;
+    NearestNeighborInterpolatorType;
   typedef LinearInterpolateImageFunction<TImage, double>
-  LinearInterpolatorType;
+    LinearInterpolatorType;
   typedef BSplineInterpolateImageFunction<TImage, double>
-  BSplineInterpolatorType;
-  typedef WindowedSincInterpolateImageFunction<TImage,
-                                               4,
-                                               Function::HammingWindowFunction<4>,
-                                               ConstantBoundaryCondition<TImage>,
-                                               double>
-  SincInterpolatorType;
+    BSplineInterpolatorType;
+  typedef WindowedSincInterpolateImageFunction<TImage, 4,
+    Function::HammingWindowFunction<4>, ConstantBoundaryCondition<TImage>,
+    double>
+    SincInterpolatorType;
   typedef ResampleImageFilter<TImage, TImage, double>
-  ResampleImageFilterType;
+    ResampleImageFilterType;
 
   typename InterpolatorType::Pointer interpolator = 0;
 
@@ -779,14 +809,17 @@ ImageToImageRegistrationHelper<TImage>
       break;
     case OptimizedRegistrationMethodType::BSPLINE_INTERPOLATION:
       interpolator = BSplineInterpolatorType::New();
-      (static_cast<BSplineInterpolatorType *>(interpolator.GetPointer() ) )->SetSplineOrder( 3 );
+      ( static_cast<BSplineInterpolatorType *>(
+        interpolator.GetPointer() ) )->SetSplineOrder( 3 );
       break;
     case OptimizedRegistrationMethodType::SINC_INTERPOLATION:
       interpolator = SincInterpolatorType::New();
       break;
     default:
-      std::cerr << "ERROR: Interpolation function not supported in itk::ImageToImageRegistrationHelper::ResampleImage"
-                << std::endl;
+      std::cerr
+        << "ERROR: Interpolation function not supported"
+        << " in itk::ImageToImageRegistrationHelper::ResampleImage"
+        << std::endl;
       interpolator = LinearInterpolatorType::New();
       break;
     }
@@ -834,8 +867,10 @@ ImageToImageRegistrationHelper<TImage>
     doBSpline = true;
     }
 
-  typename AffineTransformType::ConstPointer aTrans = m_CurrentMatrixTransform.GetPointer();
-  typename BSplineTransformType::ConstPointer bTrans = m_CurrentBSplineTransform.GetPointer();
+  typename AffineTransformType::ConstPointer aTrans =
+    m_CurrentMatrixTransform.GetPointer();
+  typename BSplineTransformType::ConstPointer bTrans =
+    m_CurrentBSplineTransform.GetPointer();
   if( matrixTransform != NULL
       || bsplineTransform != NULL )
     {
@@ -873,9 +908,12 @@ ImageToImageRegistrationHelper<TImage>
         ResampleImageFilterType::New();
       resampler->SetInput( mImage );
       resampler->SetInterpolator( interpolator.GetPointer() );
-      // We should not be casting away constness here, but SetOutputParametersFromImage
-      // Does not change the image.  This is needed to workaround fixes to ITK
-      typename ImageType::Pointer tmp = const_cast<ImageType *>(m_FixedImage.GetPointer() );
+      // We should not be casting away constness here, but
+      // SetOutputParametersFromImage
+      // Does not change the image.  This is needed to workaround fixes to
+      // ITK
+      typename ImageType::Pointer tmp = const_cast<ImageType *>(
+        m_FixedImage.GetPointer() );
       resampler->SetOutputParametersFromImage( tmp );
       resampler->SetTransform( m_LoadedMatrixTransform );
       resampler->SetDefaultPixelValue( defaultPixelValue );
@@ -903,9 +941,12 @@ ImageToImageRegistrationHelper<TImage>
         ResampleImageFilterType::New();
       resampler->SetInput( mImage );
       resampler->SetInterpolator( interpolator.GetPointer() );
-      // We should not be casting away constness here, but SetOutputParametersFromImage
-      // Does not change the image.  This is needed to workaround fixes to ITK
-      typename ImageType::Pointer tmp = const_cast<ImageType *>(m_FixedImage.GetPointer() );
+      // We should not be casting away constness here, but
+      // SetOutputParametersFromImage
+      // Does not change the image.  This is needed to workaround fixes to
+      // ITK
+      typename ImageType::Pointer tmp = const_cast<ImageType *>(
+        m_FixedImage.GetPointer() );
       resampler->SetOutputParametersFromImage( tmp );
       resampler->SetTransform( m_LoadedBSplineTransform );
       resampler->SetDefaultPixelValue( defaultPixelValue );
@@ -934,9 +975,12 @@ ImageToImageRegistrationHelper<TImage>
       ResampleImageFilterType::New();
     resampler->SetInput( mImage );
     resampler->SetInterpolator( interpolator.GetPointer() );
-    // We should not be casting away constness here, but SetOutputParametersFromImage
-    // Does not change the image.  This is needed to workaround fixes to ITK
-    typename ImageType::Pointer tmp = const_cast<ImageType *>(m_FixedImage.GetPointer() );
+    // We should not be casting away constness here, but
+    // SetOutputParametersFromImage
+    // Does not change the image.  This is needed to workaround fixes to
+    // ITK
+    typename ImageType::Pointer tmp = const_cast<ImageType *>(
+      m_FixedImage.GetPointer() );
     resampler->SetOutputParametersFromImage( tmp );
     resampler->SetTransform( aTrans );
     resampler->SetDefaultPixelValue( defaultPixelValue );
@@ -964,9 +1008,12 @@ ImageToImageRegistrationHelper<TImage>
       ResampleImageFilterType::New();
     resampler->SetInput( mImage );
     resampler->SetInterpolator( interpolator.GetPointer() );
-    // We should not be casting away constness here, but SetOutputParametersFromImage
-    // Does not change the image.  This is needed to workaround fixes to ITK
-    typename ImageType::Pointer tmp = const_cast<ImageType *>(m_FixedImage.GetPointer() );
+    // We should not be casting away constness here, but
+    // SetOutputParametersFromImage
+    // Does not change the image.  This is needed to workaround fixes to
+    // ITK
+    typename ImageType::Pointer tmp = const_cast<ImageType *>(
+      m_FixedImage.GetPointer() );
     resampler->SetOutputParametersFromImage( tmp );
     resampler->SetTransform( bTrans );
     resampler->SetDefaultPixelValue( defaultPixelValue );
@@ -989,7 +1036,8 @@ ImageToImageRegistrationHelper<TImage>
       {
       std::cout << "Resampling using identity transform." << std::endl;
       }
-    typename RigidTransformType::Pointer tmpTransform = RigidTransformType::New();
+    typename RigidTransformType::Pointer tmpTransform =
+      RigidTransformType::New();
     tmpTransform->SetIdentity();
 
     interpolator->SetInputImage( mImage );
@@ -997,9 +1045,12 @@ ImageToImageRegistrationHelper<TImage>
       ResampleImageFilterType::New();
     resampler->SetInput( mImage );
     resampler->SetInterpolator( interpolator.GetPointer() );
-    // We should not be casting away constness here, but SetOutputParametersFromImage
-    // Does not change the image.  This is needed to workaround fixes to ITK
-    typename ImageType::Pointer tmp = const_cast<ImageType *>(m_FixedImage.GetPointer() );
+    // We should not be casting away constness here, but
+    // SetOutputParametersFromImage
+    // Does not change the image.  This is needed to workaround fixes
+    // to ITK
+    typename ImageType::Pointer tmp = const_cast<ImageType *>(
+      m_FixedImage.GetPointer() );
     resampler->SetOutputParametersFromImage( tmp );
     resampler->SetTransform( tmpTransform );
     resampler->SetDefaultPixelValue( defaultPixelValue );
@@ -1047,8 +1098,9 @@ ImageToImageRegistrationHelper<TImage>
 {
   if( m_BaselineImage.IsNull() )
     {
-    std::cerr << "Error: ComputeBaselineDifference called prior to setting a baseline image."
-              << std::endl;
+    std::cerr
+      << "Error: ComputeBaselineDifference prior to set baseline image."
+      << std::endl;
     m_BaselineResampledMovingImage = NULL;
     m_BaselineDifferenceImage = NULL;
     m_BaselineNumberOfFailedPixels = 0;
@@ -1056,14 +1108,15 @@ ImageToImageRegistrationHelper<TImage>
     return;
     }
 
-  typedef Testing::ComparisonImageFilter<TImage, TImage> DifferenceFilterType;
+  typedef Testing::ComparisonImageFilter<TImage, TImage>
+    ComparisonFilterType;
 
   typename TImage::ConstPointer imTemp = this->GetFixedImage();
   this->SetFixedImage( this->m_BaselineImage );
   this->m_BaselineResampledMovingImage = this->ResampleImage();
   this->SetFixedImage( imTemp );
 
-  typename DifferenceFilterType::Pointer differ = DifferenceFilterType::New();
+  typename ComparisonFilterType::Pointer differ = ComparisonFilterType::New();
   differ->SetValidInput( this->m_BaselineImage );
   differ->SetTestInput( this->m_BaselineResampledMovingImage );
   differ->SetDifferenceThreshold( this->m_BaselineIntensityTolerance );
@@ -1179,9 +1232,11 @@ ImageToImageRegistrationHelper<TImage>
   typedef itk::Image<VectorType,3>  DisplacementFieldType;
   typedef itk::ImageRegionIterator< DisplacementFieldType > FieldIterator;
 
-  typename TImage::RegionType fixedImageRegion = m_FixedImage->GetBufferedRegion();
+  typename TImage::RegionType fixedImageRegion =
+    m_FixedImage->GetBufferedRegion();
 
-  typename DisplacementFieldType::Pointer field = DisplacementFieldType::New();
+  typename DisplacementFieldType::Pointer field =
+    DisplacementFieldType::New();
   field->SetRegions( fixedImageRegion );
   field->SetOrigin( m_FixedImage->GetOrigin() );
   field->SetSpacing( m_FixedImage->GetSpacing() );
@@ -1198,22 +1253,30 @@ ImageToImageRegistrationHelper<TImage>
   it.GoToBegin();
 
   while( ! it.IsAtEnd() )
-   {
+    {
     index = it.GetIndex();
     field->TransformIndexToPhysicalPoint( index, fixedPoint );
     movingPoint = fixedPoint;
     if(m_InitialTransform.IsNotNull())
+      {
       movingPoint = m_InitialTransform->TransformPoint( movingPoint );
+      }
     if(m_RigidTransform.IsNotNull())
+      {
       movingPoint = m_RigidTransform->TransformPoint( movingPoint );
+      }
     if(m_AffineTransform.IsNotNull())
+      {
       movingPoint = m_AffineTransform->TransformPoint( movingPoint );
+      }
     if(m_BSplineTransform.IsNotNull())
+      {
       movingPoint = m_BSplineTransform->TransformPoint( movingPoint );
+      }
     dx = movingPoint - fixedPoint;
     it.Set( dx );
     ++it;
-   }
+    }
 
   typedef itk::ImageFileWriter< DisplacementFieldType >  FieldWriterType;
   typename FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
@@ -1272,7 +1335,8 @@ ImageToImageRegistrationHelper<TImage>
 {
   if( points.size() != 2 * ImageDimension )
     {
-    throw "Error: size of points passed to SetRegionOfInterest is not twice the image dimension";
+    throw
+      "Error: points to SetRegionOfInterest is not twice image dimension";
     }
   for( unsigned int i = 0; i < ImageDimension; i++ )
     {
@@ -1288,8 +1352,9 @@ ImageToImageRegistrationHelper<TImage>
 ::SetFixedLandmarks( const std::vector<std::vector<float> > & fixedLandmarks )
 {
   m_FixedLandmarks.clear();
-  for( std::vector<std::vector<float> >::const_iterator i = fixedLandmarks.begin();
-       i != fixedLandmarks.end(); ++i )
+  for( std::vector<std::vector<float> >::const_iterator i =
+    fixedLandmarks.begin();
+    i != fixedLandmarks.end(); ++i )
     {
     LandmarkPointType landmark;
     std::copy(i->begin(), i->end(), landmark.Begin() );
@@ -1303,8 +1368,9 @@ ImageToImageRegistrationHelper<TImage>
 ::SetMovingLandmarks( const std::vector<std::vector<float> > & movingLandmarks )
 {
   m_MovingLandmarks.clear();
-  for( std::vector<std::vector<float> >::const_iterator i = movingLandmarks.begin();
-       i != movingLandmarks.end(); ++i )
+  for( std::vector<std::vector<float> >::const_iterator i =
+    movingLandmarks.begin();
+    i != movingLandmarks.end(); ++i )
     {
     LandmarkPointType landmark;
     std::copy(i->begin(), i->end(), landmark.Begin() );
@@ -1323,13 +1389,16 @@ ImageToImageRegistrationHelper<TImage>
   switch( metric )
     {
     case OptimizedRegistrationMethodType::MATTES_MI_METRIC:
-      os << indent << basename << " Metric Method = MATTES_MI_METRIC" << std::endl;
+      os << indent << basename << " Metric Method = MATTES_MI_METRIC"
+        << std::endl;
       break;
     case OptimizedRegistrationMethodType::NORMALIZED_CORRELATION_METRIC:
-      os << indent << basename << " Metric Method = CROSS_CORRELATION_METRIC" << std::endl;
+      os << indent << basename
+        << " Metric Method = CROSS_CORRELATION_METRIC" << std::endl;
       break;
     case OptimizedRegistrationMethodType::MEAN_SQUARED_ERROR_METRIC:
-      os << indent << basename << " Metric Method = MEAN_SQUARED_ERROR_METRIC" << std::endl;
+      os << indent << basename
+        << " Metric Method = MEAN_SQUARED_ERROR_METRIC" << std::endl;
       break;
     default:
       os << indent << basename << " Metric Method = UNKNOWN" << std::endl;
@@ -1340,19 +1409,25 @@ ImageToImageRegistrationHelper<TImage>
   switch( interpolation )
     {
     case OptimizedRegistrationMethodType::NEAREST_NEIGHBOR_INTERPOLATION:
-      os << indent << basename << " Interpolation Method = NEAREST_NEIGHBOR_INTERPOLATION" << std::endl;
+      os << indent << basename
+        << " Interpolation Method = NEAREST_NEIGHBOR_INTERPOLATION"
+        << std::endl;
       break;
     case OptimizedRegistrationMethodType::LINEAR_INTERPOLATION:
-      os << indent << basename << " Interpolation Method = LINEAR_INTERPOLATION" << std::endl;
+      os << indent << basename
+        << " Interpolation Method = LINEAR_INTERPOLATION" << std::endl;
       break;
     case OptimizedRegistrationMethodType::BSPLINE_INTERPOLATION:
-      os << indent << basename << " Interpolation Method = BSPLINE_INTERPOLATION" << std::endl;
+      os << indent << basename
+        << " Interpolation Method = BSPLINE_INTERPOLATION" << std::endl;
       break;
     case OptimizedRegistrationMethodType::SINC_INTERPOLATION:
-      os << indent << basename << " Interpolation Method = SINC_INTERPOLATION" << std::endl;
+      os << indent << basename
+        << " Interpolation Method = SINC_INTERPOLATION" << std::endl;
       break;
     default:
-      os << indent << basename << " Interpolation Method = UNKNOWN" << std::endl;
+      os << indent << basename
+        << " Interpolation Method = UNKNOWN" << std::endl;
       break;
     }
 }
@@ -1374,51 +1449,72 @@ ImageToImageRegistrationHelper<TImage>
     }
   os << indent << std::endl;
   os << indent << "Use region of interest = " << m_UseRegionOfInterest
-     << std::endl;
-  os << indent << "Region of interest point1 = " << m_RegionOfInterestPoint1
-     << std::endl;
-  os << indent << "Region of interest point2 = " << m_RegionOfInterestPoint2
-     << std::endl;
+    << std::endl;
+  os << indent << "Region of interest point1 = "
+    << m_RegionOfInterestPoint1 << std::endl;
+  os << indent << "Region of interest point2 = "
+    << m_RegionOfInterestPoint2 << std::endl;
   os << indent << std::endl;
-  os << indent << "Use Fixed Image Mask Object = " << m_UseFixedImageMaskObject << std::endl;
+  os << indent << "Use Fixed Image Mask Object = "
+    << m_UseFixedImageMaskObject << std::endl;
   os << indent << std::endl;
   if( m_FixedImageMaskObject.IsNotNull() )
     {
-    os << indent << "Fixed Image Mask Object = " << m_FixedImageMaskObject << std::endl;
+    os << indent << "Fixed Image Mask Object = " << m_FixedImageMaskObject
+      << std::endl;
     }
-  os << indent << "Use Moving Image Mask Object = " << m_UseMovingImageMaskObject << std::endl;
+  os << indent << "Use Moving Image Mask Object = "
+    << m_UseMovingImageMaskObject << std::endl;
   os << indent << std::endl;
   if( m_MovingImageMaskObject.IsNotNull() )
     {
-    os << indent << "Moving Image Mask Object = " << m_MovingImageMaskObject << std::endl;
+    os << indent << "Moving Image Mask Object = "
+      << m_MovingImageMaskObject << std::endl;
     }
   os << indent << std::endl;
-  os << indent << "Random Number Seed = " << m_RandomNumberSeed << std::endl;
+  os << indent << "Random Number Seed = " << m_RandomNumberSeed
+    << std::endl;
   os << indent << std::endl;
-  os << indent << "Enable Loaded Registration = " << m_EnableLoadedRegistration << std::endl;
-  os << indent << "Enable Initial Registration = " << m_EnableInitialRegistration << std::endl;
-  os << indent << "Enable Rigid Registration = " << m_EnableRigidRegistration << std::endl;
-  os << indent << "Enable Affine Registration = " << m_EnableAffineRegistration << std::endl;
-  os << indent << "Enable BSpline Registration = " << m_EnableBSplineRegistration << std::endl;
+  os << indent << "Enable Loaded Registration = "
+    << m_EnableLoadedRegistration << std::endl;
+  os << indent << "Enable Initial Registration = "
+    << m_EnableInitialRegistration << std::endl;
+  os << indent << "Enable Rigid Registration = "
+    << m_EnableRigidRegistration << std::endl;
+  os << indent << "Enable Affine Registration = "
+    << m_EnableAffineRegistration << std::endl;
+  os << indent << "Enable BSpline Registration = "
+    << m_EnableBSplineRegistration << std::endl;
   os << indent << std::endl;
-  os << indent << "Expected Offset (in Pixels) Magnitude = " << m_ExpectedOffsetPixelMagnitude << std::endl;
-  os << indent << "Expected Rotation Magnitude = " << m_ExpectedRotationMagnitude << std::endl;
-  os << indent << "Expected Scale Magnitude = " << m_ExpectedScaleMagnitude << std::endl;
-  os << indent << "Expected Skew Magnitude = " << m_ExpectedSkewMagnitude << std::endl;
+  os << indent << "Expected Offset (in Pixels) Magnitude = "
+    << m_ExpectedOffsetPixelMagnitude << std::endl;
+  os << indent << "Expected Rotation Magnitude = "
+    << m_ExpectedRotationMagnitude << std::endl;
+  os << indent << "Expected Scale Magnitude = " << m_ExpectedScaleMagnitude
+    << std::endl;
+  os << indent << "Expected Skew Magnitude = " << m_ExpectedSkewMagnitude
+    << std::endl;
   os << indent << std::endl;
-  os << indent << "Completed Initialization = " << m_CompletedInitialization << std::endl;
-  os << indent << "Completed Resampling = " << m_CompletedResampling << std::endl;
+  os << indent << "Completed Initialization = "
+    << m_CompletedInitialization << std::endl;
+  os << indent << "Completed Resampling = " << m_CompletedResampling
+    << std::endl;
   os << indent << std::endl;
-  os << indent << "Rigid Metric Value = " << m_RigidMetricValue << std::endl;
-  os << indent << "Affine Metric Value = " << m_AffineMetricValue << std::endl;
-  os << indent << "BSpline Metric Value = " << m_BSplineMetricValue << std::endl;
-  os << indent << "Final Metric Value = " << m_FinalMetricValue << std::endl;
+  os << indent << "Rigid Metric Value = " << m_RigidMetricValue
+    << std::endl;
+  os << indent << "Affine Metric Value = " << m_AffineMetricValue
+    << std::endl;
+  os << indent << "BSpline Metric Value = " << m_BSplineMetricValue
+    << std::endl;
+  os << indent << "Final Metric Value = " << m_FinalMetricValue
+    << std::endl;
   os << indent << std::endl;
   os << indent << "Report Progress = " << m_ReportProgress << std::endl;
   os << indent << std::endl;
   if( m_CurrentMovingImage.IsNotNull() )
     {
-    os << indent << "Current Moving Image = " << m_CurrentMovingImage << std::endl;
+    os << indent << "Current Moving Image = " << m_CurrentMovingImage
+      << std::endl;
     }
   else
     {
@@ -1426,7 +1522,8 @@ ImageToImageRegistrationHelper<TImage>
     }
   if( m_CurrentMatrixTransform.IsNotNull() )
     {
-    os << indent << "Current Matrix Transform = " << m_CurrentMatrixTransform << std::endl;
+    os << indent << "Current Matrix Transform = "
+      << m_CurrentMatrixTransform << std::endl;
     }
   else
     {
@@ -1434,7 +1531,8 @@ ImageToImageRegistrationHelper<TImage>
     }
   if( m_CurrentBSplineTransform.IsNotNull() )
     {
-    os << indent << "Current BSpline Transform = " << m_CurrentBSplineTransform << std::endl;
+    os << indent << "Current BSpline Transform = "
+      << m_CurrentBSplineTransform << std::endl;
     }
   else
     {
@@ -1443,7 +1541,8 @@ ImageToImageRegistrationHelper<TImage>
   os << indent << std::endl;
   if( m_LoadedTransformResampledImage.IsNotNull() )
     {
-    os << indent << "Loaded Transform Resampled Image = " << m_LoadedTransformResampledImage << std::endl;
+    os << indent << "Loaded Transform Resampled Image = "
+      << m_LoadedTransformResampledImage << std::endl;
     }
   else
     {
@@ -1451,7 +1550,8 @@ ImageToImageRegistrationHelper<TImage>
     }
   if( m_MatrixTransformResampledImage.IsNotNull() )
     {
-    os << indent << "Matrix Transform Resampled Image = " << m_MatrixTransformResampledImage << std::endl;
+    os << indent << "Matrix Transform Resampled Image = "
+      << m_MatrixTransformResampledImage << std::endl;
     }
   else
     {
@@ -1459,16 +1559,19 @@ ImageToImageRegistrationHelper<TImage>
     }
   if( m_BSplineTransformResampledImage.IsNotNull() )
     {
-    os << indent << "BSpline Transform Resampled Image = " << m_BSplineTransformResampledImage << std::endl;
+    os << indent << "BSpline Transform Resampled Image = "
+      << m_BSplineTransformResampledImage << std::endl;
     }
   else
     {
-    os << indent << "BSpline Transform Resampled Image = NULL" << std::endl;
+    os << indent << "BSpline Transform Resampled Image = NULL"
+      << std::endl;
     }
   os << indent << std::endl;
   if( m_LoadedMatrixTransform.IsNotNull() )
     {
-    os << indent << "Loaded Matrix Transform = " << m_LoadedMatrixTransform << std::endl;
+    os << indent << "Loaded Matrix Transform = " << m_LoadedMatrixTransform
+      << std::endl;
     }
   else
     {
@@ -1476,7 +1579,8 @@ ImageToImageRegistrationHelper<TImage>
     }
   if( m_LoadedBSplineTransform.IsNotNull() )
     {
-    os << indent << "Loaded BSpline Transform = " << m_LoadedBSplineTransform << std::endl;
+    os << indent << "Loaded BSpline Transform = "
+      << m_LoadedBSplineTransform << std::endl;
     }
   else
     {
@@ -1487,19 +1591,28 @@ ImageToImageRegistrationHelper<TImage>
   switch( m_InitialMethodEnum )
     {
     case INIT_WITH_NONE:
-      os << indent << "Initial Registration Enum = INIT_WITH_NONE" << std::endl;
+      os << indent << "Initial Registration Enum = INIT_WITH_NONE"
+        << std::endl;
       break;
     case INIT_WITH_CURRENT_RESULTS:
-      os << indent << "Initial Registration Enum = INIT_WITH_CURRENT_RESULTS" << std::endl;
+      os << indent
+        << "Initial Registration Enum = INIT_WITH_CURRENT_RESULTS"
+        << std::endl;
       break;
     case INIT_WITH_IMAGE_CENTERS:
-      os << indent << "Initial Registration Enum = INIT_WITH_IMAGE_CENTERS" << std::endl;
+      os << indent
+        << "Initial Registration Enum = INIT_WITH_IMAGE_CENTERS"
+        << std::endl;
       break;
     case INIT_WITH_CENTERS_OF_MASS:
-      os << indent << "Initial Registration Enum = INIT_WITH_CENTERS_OF_MASS" << std::endl;
+      os << indent
+        << "Initial Registration Enum = INIT_WITH_CENTERS_OF_MASS"
+        << std::endl;
       break;
     case INIT_WITH_SECOND_MOMENTS:
-      os << indent << "Initial Registration Enum = INIT_WITH_SECOND_MOMENTS" << std::endl;
+      os << indent
+        << "Initial Registration Enum = INIT_WITH_SECOND_MOMENTS"
+        << std::endl;
       break;
     default:
       os << indent << "Initial Registration Enum = UNKNOWN" << std::endl;
@@ -1507,16 +1620,20 @@ ImageToImageRegistrationHelper<TImage>
     }
   if( m_InitialTransform.IsNotNull() )
     {
-    os << indent << "Initial Transform = " << m_InitialTransform << std::endl;
+    os << indent << "Initial Transform = " << m_InitialTransform
+      << std::endl;
     }
   else
     {
     os << indent << "Initial Transform = NULL" << std::endl;
     }
   os << indent << std::endl;
-  os << indent << "Rigid Sampling Ratio = " << m_RigidSamplingRatio << std::endl;
-  os << indent << "Rigid Target Error = " << m_RigidTargetError << std::endl;
-  os << indent << "Rigid Max Iterations = " << m_RigidMaxIterations << std::endl;
+  os << indent << "Rigid Sampling Ratio = " << m_RigidSamplingRatio
+    << std::endl;
+  os << indent << "Rigid Target Error = " << m_RigidTargetError
+    << std::endl;
+  os << indent << "Rigid Max Iterations = " << m_RigidMaxIterations
+    << std::endl;
   PrintSelfHelper( os, indent, "Rigid", m_RigidMetricMethodEnum,
                    m_RigidInterpolationMethodEnum );
   os << indent << std::endl;
@@ -1529,31 +1646,40 @@ ImageToImageRegistrationHelper<TImage>
     os << indent << "Rigid Transform = NULL" << std::endl;
     }
   os << indent << std::endl;
-  os << indent << "Affine Sampling Ratio = " << m_AffineSamplingRatio << std::endl;
-  os << indent << "Affine Target Error = " << m_AffineTargetError << std::endl;
-  os << indent << "Affine Max Iterations = " << m_AffineMaxIterations << std::endl;
+  os << indent << "Affine Sampling Ratio = " << m_AffineSamplingRatio
+    << std::endl;
+  os << indent << "Affine Target Error = " << m_AffineTargetError
+    << std::endl;
+  os << indent << "Affine Max Iterations = " << m_AffineMaxIterations
+    << std::endl;
   PrintSelfHelper( os, indent, "Affine", m_AffineMetricMethodEnum,
-                   m_AffineInterpolationMethodEnum );
+    m_AffineInterpolationMethodEnum );
   os << indent << std::endl;
   if( m_AffineTransform.IsNotNull() )
     {
-    os << indent << "Affine Transform = " << m_AffineTransform << std::endl;
+    os << indent << "Affine Transform = " << m_AffineTransform
+      << std::endl;
     }
   else
     {
     os << indent << "Affine Transform = NULL" << std::endl;
     }
   os << indent << std::endl;
-  os << indent << "BSpline Sampling Ratio = " << m_BSplineSamplingRatio << std::endl;
-  os << indent << "BSpline Target Error = " << m_BSplineTargetError << std::endl;
-  os << indent << "BSpline Max Iterations = " << m_BSplineMaxIterations << std::endl;
-  os << indent << "BSpline Control Point Pixel Spacing = " << m_BSplineControlPointPixelSpacing << std::endl;
+  os << indent << "BSpline Sampling Ratio = " << m_BSplineSamplingRatio
+    << std::endl;
+  os << indent << "BSpline Target Error = " << m_BSplineTargetError
+    << std::endl;
+  os << indent << "BSpline Max Iterations = " << m_BSplineMaxIterations
+    << std::endl;
+  os << indent << "BSpline Control Point Pixel Spacing = "
+    << m_BSplineControlPointPixelSpacing << std::endl;
   PrintSelfHelper( os, indent, "BSpline", m_BSplineMetricMethodEnum,
-                   m_BSplineInterpolationMethodEnum );
+    m_BSplineInterpolationMethodEnum );
   os << indent << std::endl;
   if( m_BSplineTransform.IsNotNull() )
     {
-    os << indent << "BSpline Transform = " << m_BSplineTransform << std::endl;
+    os << indent << "BSpline Transform = " << m_BSplineTransform
+      << std::endl;
     }
   else
     {
@@ -1563,6 +1689,6 @@ ImageToImageRegistrationHelper<TImage>
 
 }
 
-};
+}
 
 #endif

--- a/Base/Segmentation/Testing/itktubeRadiusExtractorTest.cxx
+++ b/Base/Segmentation/Testing/itktubeRadiusExtractorTest.cxx
@@ -146,8 +146,6 @@ int itktubeRadiusExtractorTest( int argc, char * argv[] )
       {
       ++tubeIter;
       }
-    TubeType * tubep = static_cast< TubeType * >(
-      tubeIter->GetPointer() );
     TubeType::Pointer tube = static_cast< TubeType * >(
       tubeIter->GetPointer() );
     tube::ComputeTubeTangentsAndNormals< TubeType >( tube );

--- a/CMake/TubeTKBlockSetCMakeOSXVariables.cmake
+++ b/CMake/TubeTKBlockSetCMakeOSXVariables.cmake
@@ -27,7 +27,8 @@
 #
 
 # Note: Change architecture *before* any enable_language() or project()
-#       calls so that it's set properly to detect 64-bit-ness...
+#       calls so that it's set properly to detect 64-bit-ness, and
+#       deployment target for the standard c++ library.
 #
 if(APPLE)
 
@@ -47,45 +48,80 @@ if(APPLE)
   #  11.x == Mac OSX 10.7 (Lion)
   #  12.x == Mac OSX 10.8 (Mountain Lion)
   #  13.x == Mac OSX 10.9 (Mavericks)
+  #  14.x == Mac OSX 10.10 (Yosemite)
   set(OSX_SDK_104_NAME "Tiger")
   set(OSX_SDK_105_NAME "Leopard")
   set(OSX_SDK_106_NAME "Snow Leopard")
   set(OSX_SDK_107_NAME "Lion")
   set(OSX_SDK_108_NAME "Mountain Lion")
   set(OSX_SDK_109_NAME "Mavericks")
+  set(OSX_SDK_1010_NAME "Yosemite")
 
   set(OSX_SDK_ROOTS
     /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs
     /Developer/SDKs
     )
-  set(SDK_VERSIONS_TO_CHECK 10.10 10.9 10.8 10.7 10.6 10.5)
-  foreach(SDK_VERSION ${SDK_VERSIONS_TO_CHECK})
-    if(NOT CMAKE_OSX_DEPLOYMENT_TARGET OR "${CMAKE_OSX_DEPLOYMENT_TARGET}" STREQUAL "")
-      foreach(SDK_ROOT ${OSX_SDK_ROOTS})
-        set(TEST_OSX_SYSROOT "${SDK_ROOT}/MacOSX${SDK_VERSION}.sdk")
-        if(EXISTS "${TEST_OSX_SYSROOT}")
-          # Retrieve OSX target name
+
+  # Explicitly set the OSX_SYSROOT to the latest one, as its required
+  #       when the SX_DEPLOYMENT_TARGET is explicitly set
+  foreach(SDK_ROOT ${OSX_SDK_ROOTS})
+    if( "x${CMAKE_OSX_SYSROOT}x" STREQUAL "xx")
+      file(GLOB SDK_SYSROOTS "${SDK_ROOT}/MacOSX*.sdk")
+
+      if(NOT "x${SDK_SYSROOTS}x" STREQUAL "xx")
+        set(SDK_SYSROOT_NEWEST "")
+        set(SDK_VERSION "0")
+        # find the latest SDK
+        foreach(SDK_ROOT_I ${SDK_SYSROOTS})
+          # extract version from SDK
+          string(REGEX MATCH "MacOSX([0-9]+\\.[0-9]+)\\.sdk" _match "${SDK_ROOT_I}")
+          if("${CMAKE_MATCH_1}" VERSION_GREATER "${SDK_VERSION}")
+            set(SDK_SYSROOT_NEWEST "${SDK_ROOT_I}")
+            set(SDK_VERSION "${CMAKE_MATCH_1}")
+          endif()
+        endforeach()
+
+        if(NOT "x${SDK_SYSROOT_NEWEST}x" STREQUAL "xx")
           string(REPLACE "." "" sdk_version_no_dot ${SDK_VERSION})
           set(OSX_NAME ${OSX_SDK_${sdk_version_no_dot}_NAME})
           set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "Force build for 64-bit ${OSX_NAME}." FORCE)
-          set(CMAKE_OSX_DEPLOYMENT_TARGET "${SDK_VERSION}" CACHE STRING "Force build for 64-bit ${OSX_NAME}." FORCE)
-          set(CMAKE_OSX_SYSROOT "${TEST_OSX_SYSROOT}" CACHE PATH "Force build for 64-bit ${OSX_NAME}." FORCE)
+          set(CMAKE_OSX_SYSROOT "${SDK_SYSROOT_NEWEST}" CACHE PATH "Force build for 64-bit ${OSX_NAME}." FORCE)
           message(STATUS "Setting OSX_ARCHITECTURES to '${CMAKE_OSX_ARCHITECTURES}' as none was specified.")
-          message(STATUS "Setting OSX_DEPLOYMENT_TARGET to '${SDK_VERSION}' as none was specified.")
-          message(STATUS "Setting OSX_SYSROOT to '${TEST_OSX_SYSROOT}' as none was specified.")
+          message(STATUS "Setting OSX_SYSROOT to latest '${CMAKE_OSX_SYSROOT}' as none was specified.")
         endif()
-      endforeach()
+      endif()
     endif()
   endforeach()
+
+  if("x${CMAKE_OSX_DEPLOYMENT_TARGET}x" STREQUAL "xx")
+    string(REGEX MATCH "MacOSX([0-9]+\\.[0-9]+)\\.sdk" _match "${CMAKE_OSX_SYSROOT}")
+    set(SDK_VERSION "${CMAKE_MATCH_1}")
+    if( "${SDK_VERSION}" VERSION_GREATER "10.8" )
+      # add to cache to allow interactive editing after fatal error
+      set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE PATH "Deployment target needs to be explicitly set." FORCE)
+      message(FATAL_ERROR
+        "The OSX_SYSROOT is set to version ${SDK_VERSION} (>10.8) and OSX_DEPLOYMENT_TARGET is not explicitly set!\n"
+        "Since:\n"
+        " (1) the default runtime associated with >=10.9 deployment target is 'libc++'.[1]\n"
+        " (2) the default runtime associated with <=10.8 deployment target is 'libstdc++'.\n"
+        " (3) Qt support for 'macx-clang-libc++' is listed as 'unsupported' mkspecs.\n"
+        " (4) Qt binaries may be build against 'libstdc++' or 'libc++'.\n"
+        " (5) Mixing the two different runtime in binaries is unstable.\n"
+        "  [1]http://stackoverflow.com/questions/19637164/c-linking-error-after-upgrading-to-mac-os-x-10-9-xcode-5-0-1/19637199#19637199\n"
+        "--------------------------------\n"
+        "Run '$otool -L $(which qmake) |grep lib.\\*c++' to check what library Qt is built against:\n"
+        " (1) if it is libstdc++ then add '-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.8' (or older) to the cmake command line.\n"
+        " (2) if it is libc++ then add '-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9' (or newer) to the cmake command line.\n"
+        )
+    endif()
+  endif()
 
   if(NOT "${CMAKE_OSX_SYSROOT}" STREQUAL "")
     if(NOT EXISTS "${CMAKE_OSX_SYSROOT}")
       message(FATAL_ERROR "error: CMAKE_OSX_SYSROOT='${CMAKE_OSX_SYSROOT}' does not exist")
     endif()
   endif()
-
   mark_as_advanced( CMAKE_OSX_ARCHITECTURES )
   mark_as_advanced( CMAKE_OSX_DEPLOYMENT_TARGET )
   mark_as_advanced( CMAKE_OSX_SYSROOT )
-
 endif()


### PR DESCRIPTION
Fixed formatting per KWStyle specification.
Updated handling of CMake OSX vars based on BlockSet macro from Slicer.
Updated TubeMathTest.
