### PR TITLE
BUG: Fix 3 issues in SpatialObjects Module

### DIFF
--- a/SlicerModules/SpatialObjectsModule/Widgets/qSlicerSpatialObjectsWidget.cxx
+++ b/SlicerModules/SpatialObjectsModule/Widgets/qSlicerSpatialObjectsWidget.cxx
@@ -620,7 +620,7 @@ void qSlicerSpatialObjectsWidget::updateWidgetFromMRML()
      != d->SpatialObjectsDisplayNode->GetActiveScalarName()))
     {
     d->ColorByScalarComboBox->setCurrentArray(
-    d->SpatialObjectsDisplayNode->GetActiveScalarName());
+      d->SpatialObjectsDisplayNode->GetActiveScalarName());
     }
 
 

--- a/SlicerModules/SpatialObjectsModule/Widgets/qSlicerSpatialObjectsWidget.cxx
+++ b/SlicerModules/SpatialObjectsModule/Widgets/qSlicerSpatialObjectsWidget.cxx
@@ -348,6 +348,7 @@ void qSlicerSpatialObjectsWidget::setColorByScalar()
     return;
     }
 
+  d->SpatialObjectsDisplayNode->SetScalarRangeFlag(vtkMRMLDisplayNode::UseDisplayNodeScalarRange);
   d->SpatialObjectsDisplayNode->SetColorModeToScalarData();
   d->SpatialObjectsDisplayNode->SetScalarVisibility(1);
   this->onColorByScalarChanged(d->ColorByScalarComboBox->currentIndex());


### PR DESCRIPTION
- https://github.com/KitwareMedical/VesselView/issues/30
Crash when selecting a spatialobjectnode, on an assert error in a ctkRangeWidget.
Needed to set SingleStep before Range

- https://github.com/KitwareMedical/VesselView/issues/93
ColorByScalarComboBox has wrong behavior when switching between 2 nodes
Needed to set CurrentArray of ColorByScalarComboBox in updateWidgetFromMRML