### PR TITLE
Gaussian distance smoothing crash

### DIFF
--- a/Base/IO/itktubeTubeXIO.hxx
+++ b/Base/IO/itktubeTubeXIO.hxx
@@ -281,6 +281,7 @@ TubeXIO< TDimension >
 
     tube->SetSpacing( voxelSize );
     tube->SetId( tubeId );
+    tube->RemoveDuplicatePoints();
     tube->ComputeTangentAndNormals();
 
     m_TubeGroup->AddSpatialObject( tube );

--- a/Base/Numerics/Testing/tubeTubeMathTest.cxx
+++ b/Base/Numerics/Testing/tubeTubeMathTest.cxx
@@ -112,7 +112,7 @@ int tubeTubeMathTest( int tubeNotUsed( argc ),
     std::cout << "Length = " << t2Length << std::endl;
     if( tLength <= t2Length )
       {
-      std::cout << "ERROR: Raw length = " << tLength
+      std::cerr << "ERROR: Raw length = " << tLength
         << " <= Smooth length = " << t2Length << std::endl;
       returnStatus = EXIT_FAILURE;
       }
@@ -136,7 +136,7 @@ int tubeTubeMathTest( int tubeNotUsed( argc ),
     std::cout << "Length = " << t2Length << std::endl;
     if( tLength <= t2Length )
       {
-      std::cout << "ERROR: Raw length = " << tLength
+      std::cerr << "ERROR: Raw length = " << tLength
         << " <= Smooth length = " << t2Length << std::endl;
       returnStatus = EXIT_FAILURE;
       }
@@ -164,13 +164,13 @@ int tubeTubeMathTest( int tubeNotUsed( argc ),
     std::cout<< "Number of Points = " << t3NumPoints <<std::endl;
     if( tLength <= t3Length )
       {
-      std::cout << "ERROR: Raw length = " << tLength
+      std::cerr << "ERROR: Raw length = " << tLength
         << " <= Smooth length = " << t3Length << std::endl;
       returnStatus = EXIT_FAILURE;
       }
     if( t3NumPoints >= tNumPoints)
       {
-      std::cout << "ERROR: Raw: NumberOfPoints = " << tube->GetNumberOfPoints()
+      std::cerr << "ERROR: Raw: NumberOfPoints = " << tube->GetNumberOfPoints()
         << " <= Subsampled: NumberOfPoints = " << tube3->GetNumberOfPoints()
         << std::endl;
       returnStatus = EXIT_FAILURE;

--- a/Base/Numerics/tubeTubeMath.hxx
+++ b/Base/Numerics/tubeTubeMath.hxx
@@ -189,7 +189,7 @@ ComputeVectorTangentsAndNormals( std::vector< TTubePoint > & tubeV )
     l = vcl_sqrt(l);
     if(l < 0.0001)
       {
-      std::cerr << "TubeSpatialObject::ComputeTangentAndNormals() : ";
+      std::cerr << "tubeTubeMath::ComputeVectorTangentsAndNormals() : ";
       std::cerr << "length between two consecutive points is 0";
       std::cerr << " (use RemoveDuplicatePoints())" << std::endl;
       std::cerr << "   p1 = " << x1 << std::endl;
@@ -344,8 +344,8 @@ SmoothTube( const typename TTube::Pointer & tube, double h,
     // w[pos] = 1/(sigma*2.50663)*exp(-dist*dist/(2.0*sigma*sigma));
 
     // TODO : Finish implementation
-    std::cerr<<" Function not yet implemented, results you might get are false.\n";
-
+    std::cerr<<" Smoothing method not yet implemented. Please choose another one.\n";
+    return NULL;
     }
 
   newTube->SetPoints( newPointList );


### PR DESCRIPTION
- Fix crash when selecting Gaussian Distance smoothing method which isn't yet implemented
- Correct cout to cerr in tubeTubeMathTest.
- Remove duplicate points when converting TubeX to TubeTK format -> avoid warnings