### PR TITLE
BUG: avoid de-allocation of container in ExtractTubePointsSpatialObjectFilter

### DIFF
--- a/Base/CMakeLists.txt
+++ b/Base/CMakeLists.txt
@@ -21,17 +21,26 @@
 #
 ##############################################################################
 
+include_directories( CLI
+  Common
+  IO
+  ObjectDocuments
+  Numerics
+  Filtering
+  Registration
+  Segmentation
+  )
 add_subdirectory( CLI )
 add_subdirectory( Common )
-add_subdirectory( Filtering )
 add_subdirectory( IO )
-add_subdirectory( Numerics )
 add_subdirectory( ObjectDocuments )
+add_subdirectory( Numerics )
 
 if( TubeTK_USE_PYTHON )
   add_subdirectory( Python )
 endif( TubeTK_USE_PYTHON )
 
+add_subdirectory( Filtering )
 add_subdirectory( Registration )
 add_subdirectory( Segmentation )
 add_subdirectory( USTK )

--- a/Base/Filtering/CMakeLists.txt
+++ b/Base/Filtering/CMakeLists.txt
@@ -82,10 +82,6 @@ if( TubeTK_USE_GPU_ARRAYFIRE )
 
 endif( TubeTK_USE_GPU_ARRAYFIRE )
 
-include_directories(
-  ${TubeTK_SOURCE_DIR}/Base/Common
-  ${TubeTK_SOURCE_DIR}/Base/Numerics )
-
 add_library( TubeTKFiltering INTERFACE )
 
 target_link_libraries( TubeTKFiltering INTERFACE

--- a/Base/Filtering/Testing/itktubeExtractTubePointsSpatialObjectFilterTest.cxx
+++ b/Base/Filtering/Testing/itktubeExtractTubePointsSpatialObjectFilterTest.cxx
@@ -86,8 +86,15 @@ int itktubeExtractTubePointsSpatialObjectFilterTest( int argc, char* argv[] )
 
   typedef ExtractTubePointsSpatialObjectFilterType::PointsContainerType
     PointsContainerType;
+
   const PointsContainerType * pointsContainer =
     extractTubePointsFilter->GetPointsContainer();
+  if( pointsContainer == NULL )
+    {
+    std::cerr << "Point container is null" << std::endl;
+    return EXIT_FAILURE;
+    }
+
   const itk::SizeValueType numberOfPoints = pointsContainer->Size();
   std::cout << "Output points container size: " << numberOfPoints
     << std::endl;

--- a/Base/Filtering/Testing/itktubeExtractTubePointsSpatialObjectFilterTest.cxx
+++ b/Base/Filtering/Testing/itktubeExtractTubePointsSpatialObjectFilterTest.cxx
@@ -118,7 +118,7 @@ int itktubeExtractTubePointsSpatialObjectFilterTest( int argc, char* argv[] )
               << std::endl;
     }
 
-  delete pointsContainer;
+  //delete pointsContainer;
 
   return EXIT_SUCCESS;
 }

--- a/Base/Filtering/itktubeExtractTubePointsSpatialObjectFilter.h
+++ b/Base/Filtering/itktubeExtractTubePointsSpatialObjectFilter.h
@@ -40,10 +40,10 @@ namespace tube
  *
  * ExtractTubePointsSpatialObjectFilter iterates through a tree of
  * TubeSpatialObject's (or classes derived from
- * itk::TubeSpatialObject), and places all the TubeSpatialObjectPointType points
+ * itk::TubeSpatialObject), and places all the TubeSpatialObjectPointType
+ * points
  * into an itk::VectorContainer< TubeSpatialObjectType::TubePointType >.
  * It is assumed that
- *
  * This filter is templated over the type of the TubeSpatialObject.
  *
  * \sa GroupSpatialObject
@@ -57,18 +57,22 @@ class ExtractTubePointsSpatialObjectFilter : public ProcessObject
 {
 public:
   /** Standard class typedefs. */
-  typedef ExtractTubePointsSpatialObjectFilter  Self;
-  typedef ProcessObject                         Superclass;
-  typedef SmartPointer< Self >                  Pointer;
-  typedef SmartPointer< const Self >            ConstPointer;
+  typedef ExtractTubePointsSpatialObjectFilter Self;
+  typedef ProcessObject                        Superclass;
+  typedef SmartPointer< Self >                 Pointer;
+  typedef SmartPointer< const Self >           ConstPointer;
 
-  typedef TTubeSpatialObject                               TubeSpatialObjectType;
-  typedef typename TubeSpatialObjectType::TubePointType    TubePointType;
+  typedef TTubeSpatialObject                   TubeSpatialObjectType;
+
+  typedef typename TTubeSpatialObject::TubePointType   TubePointType;
+
   typedef VectorContainer< IdentifierType, TubePointType > PointsContainerType;
-  typedef DataObjectDecorator< PointsContainerType >       PointsContainerDecoratorType;
+
+  typedef DataObjectDecorator< PointsContainerType >
+                                               PointsContainerDecoratorType;
 
   typedef GroupSpatialObject< TubeSpatialObjectType::ObjectDimension >
-    GroupSpatialObjectType;
+                                               GroupSpatialObjectType;
 
   /** Run-time type information (and related methods). */
   itkTypeMacro( ExtractTubePointsSpatialObjectFilter, ProcessObject );
@@ -82,7 +86,7 @@ public:
   const GroupSpatialObjectType * GetInput( void ) const;
 
   /** Get the output PointsContainerType decorated as an itk::DataObject. */
-  PointsContainerDecoratorType * GetPointsContainerOutput( void );
+  PointsContainerDecoratorType *       GetPointsContainerOutput( void );
   const PointsContainerDecoratorType * GetPointsContainerOutput( void ) const;
 
   /** Get the output PointsContainerType. */
@@ -99,10 +103,14 @@ protected:
   virtual void GenerateData();
 
 private:
-  ExtractTubePointsSpatialObjectFilter( const Self & ); // purposely not implemented
-  void operator=( const Self & );      // purposely not implemented
+  // purposely not implemented
+  ExtractTubePointsSpatialObjectFilter( const Self & );
 
-  typename PointsContainerType::Pointer m_PointsContainer;
+  // purposely not implemented
+  void operator=( const Self & );
+
+  typename PointsContainerDecoratorType::Pointer m_PointsContainerDecorator;
+  typename PointsContainerType::Pointer          m_PointsContainer;
 
 }; // End class ExtractTubePointsSpatialObjectFilter
 

--- a/Base/Numerics/CMakeLists.txt
+++ b/Base/Numerics/CMakeLists.txt
@@ -62,10 +62,6 @@ set( TubeTK_Base_Numerics_HXX_Files
   tubeMatrixMath.hxx
   tubeTubeMath.hxx )
 
-include_directories(
-  ${TubeTK_SOURCE_DIR}/Base/Filtering
-  ${TubeTK_SOURCE_DIR}/Base/Common )
-
 set( TubeTK_Base_Numerics_SRCS
   tubeBrentOptimizer1D.cxx
   tubeGoldenMeanOptimizer1D.cxx
@@ -82,8 +78,7 @@ add_library( TubeTKNumerics STATIC
   ${TubeTK_Base_Numerics_SRCS} )
 
 target_link_libraries( TubeTKNumerics
-  TubeTKCommon TubeTKFiltering
-  ${ITK_LIBRARIES} )
+  TubeTKCommon ${ITK_LIBRARIES} )
 
 set( TARGETS TubeTKNumerics )
 TubeTKMacroInstallPlugins( ${TARGETS} )

--- a/Base/Numerics/tubeTubeMath.h
+++ b/Base/Numerics/tubeTubeMath.h
@@ -20,7 +20,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 =========================================================================*/
-
 #ifndef __tubeTubeMath_h
 #define __tubeTubeMath_h
 
@@ -44,15 +43,17 @@ template< class TTubePoint >
 bool
 ComputeVectorTangentsAndNormals( std::vector< TTubePoint > & tube );
 
-enum SmoothTubeFunctionEnum {
-  SMOOTH_TUBE_USING_INDEX_AVERAGE,
-  SMOOTH_TUBE_USING_INDEX_GAUSSIAN,
-  SMOOTH_TUBE_USING_DISTANCE_GAUSSIAN};
+enum SmoothTubeFunctionEnum { SMOOTH_TUBE_USING_INDEX_AVERAGE,
+  SMOOTH_TUBE_USING_INDEX_GAUSSIAN, SMOOTH_TUBE_USING_DISTANCE_GAUSSIAN };
 
 template< class TTube >
 typename TTube::Pointer
 SmoothTube( const typename TTube::Pointer & tube, double h = 2,
   SmoothTubeFunctionEnum smoothFunction = SMOOTH_TUBE_USING_INDEX_AVERAGE );
+
+template< class TTube >
+int
+RemoveDuplicateTubePoints( typename TTube::Pointer & tube );
 
 template< class TTube >
 typename TTube::Pointer

--- a/Base/Numerics/tubeTubeMath.hxx
+++ b/Base/Numerics/tubeTubeMath.hxx
@@ -352,6 +352,43 @@ SmoothTube( const typename TTube::Pointer & tube, double h,
 }
 
 
+/** Remove duplicate points */
+template< class TTube >
+int
+RemoveDuplicateTubePoints( typename TTube::Pointer & tube )
+{
+  int length = tube->GetNumberOfPoints();
+
+  if ( length <= 1 )
+    {
+    return 0;
+    }
+
+  int nPoints = 0;
+  for ( int i = 0; i < length - 1; i++ )
+    {
+    if ( tube->GetPoint(i)->GetPosition() ==
+      tube->GetPoint(i + 1)->GetPosition() )
+      {
+      tube->RemovePoint(i + 1);
+      i--;
+      length--;
+      nPoints++;
+      }
+    if ( i >= 0 && i < length - 2
+         && tube->GetPoint(i)->GetPosition() ==
+         tube->GetPoint(i + 2)->GetPosition() )
+      {
+      tube->RemovePoint(i + 2);
+      i--;
+      length--;
+      nPoints++;
+      }
+    }
+
+  return nPoints;
+}
+
 /**
  * Subsample a tube */
 template< class TTube >

--- a/Base/ObjectDocuments/CMakeLists.txt
+++ b/Base/ObjectDocuments/CMakeLists.txt
@@ -49,7 +49,6 @@ add_library( TubeTKObjectDocuments STATIC
   ${TubeTk_Base_ObjectDocuments_HXX_Files}
   ${TubeTk_Base_ObjectDocuments_SRCS} )
 
-include_directories( ${TubeTK_SOURCE_DIR}/Base/Common )
 target_link_libraries( TubeTKObjectDocuments TubeTKCommon ${ITK_LIBRARIES} ITKIOMeta ITKIOSpatialObjects )
 
 set( TARGETS TubeTKObjectDocuments )

--- a/Base/ParameterSerializer/CMakeLists.txt
+++ b/Base/ParameterSerializer/CMakeLists.txt
@@ -24,7 +24,7 @@
 project( TubeTKParameterSerializer )
 
 find_package( JsonCpp REQUIRED )
-include_directories( ${JsonCpp_INCLUDE_DIRS} )
+#include_directories( ${JsonCpp_INCLUDE_DIRS} )
 
 set( TubeTK_Base_ParameterSerializer_H_Files
   Registration/itktubeTubeAngleOfIncidenceWeightFunctionSerializer.h

--- a/Base/Python/CMakeLists.txt
+++ b/Base/Python/CMakeLists.txt
@@ -48,8 +48,6 @@ if( BUILD_TESTING AND NOT TubeTK_BUILD_USING_SLICER )
   endif( ${_result_variable} )
 endif( BUILD_TESTING AND NOT TubeTK_BUILD_USING_SLICER )
 
-include_directories( ${TubeTK_SOURCE_DIR}/Base/Filtering )
-
 add_subdirectory( tubetk )
 
 if( BUILD_TESTING AND NOT TubeTK_BUILD_USING_SLICER )


### PR DESCRIPTION
Output data structure was being de-allocated because of mixing of raw and smart pointers.

Now preserving output data structure as a member variable.