### PR TITLE
Fix: Adding TubeTK_BINARY_DIR to TubeTK_INCLUDE_DIRS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -661,6 +661,7 @@ make_directory( ${TubeTK_BINARY_DIR}/Temporary )
 
 # Configure variables to export.
 set( TubeTK_INCLUDE_DIRS
+  ${TubeTK_BINARY_DIR}
   ${TubeTK_SOURCE_DIR}/Base/CLI
   ${TubeTK_SOURCE_DIR}/Base/Common
   ${TubeTK_SOURCE_DIR}/Base/Filtering


### PR DESCRIPTION
to make sure that tubetkConfigure.h is seen when built by vesselview/slicer