### PR TITLE
BUG: Fix MetaCommand linking error

### DIFF
--- a/Base/Common/CMakeLists.txt
+++ b/Base/Common/CMakeLists.txt
@@ -66,10 +66,11 @@ add_executable( JsonCompareCommand JsonCompareCommand.cxx )
 target_link_libraries( JsonCompareCommand
   ${ITK_LIBRARIES}
   ITKIOMeta
+  ITKMetaIO
   ${JsonCpp_LIBRARIES} )
 
 add_executable( TextCompareCommand TextCompareCommand.cxx )
-target_link_libraries( TextCompareCommand ${ITK_LIBRARIES} ITKIOMeta )
+target_link_libraries( TextCompareCommand ${ITK_LIBRARIES} ITKIOMeta ITKMetaIO)
 
 if( BUILD_TESTING )
   add_subdirectory( Testing )


### PR DESCRIPTION
This commit adds ITKMetaIO as a dependency for the CompareCommand
modules from Base/Common.
This fixes the following error [1] thrown by the TextCompareCommand
and JsonCompareCommand modules.

[1] : undefined reference to `MetaCommand::MetaCommand()'