### PR TITLE
ENH: Improve detection for box belonging

### DIFF
--- a/Applications/ClipTubes/ClipTubes.cxx
+++ b/Applications/ClipTubes/ClipTubes.cxx
@@ -58,8 +58,8 @@ bool isInside( itk::Point< double, DimensionT > pointPos, double tubeRadius,
       {
       hasXInside = true;
       }
-    if( pointPos[1] - tubeRadius * normalList[i][1] <= boxPos[1] &&
-      pointPos[1] + tubeRadius * normalList[i][1] >= boxPos[1] - boxSize[1] )
+    if( pointPos[1] + tubeRadius * normalList[i][1] >= boxPos[1] &&
+      pointPos[1] - tubeRadius * normalList[i][1] <= boxPos[1] + boxSize[1] )
       {
       hasYInside = true;
       }
@@ -105,7 +105,7 @@ void writeBox( std::vector< double > boxPos, std::vector< double > boxSize,
       vtkSmartPointer<vtkCubeSource>::New();
     cubeSource->SetBounds(
       -spacing[0] * (boxPos[0] + boxSize[0]), -spacing[0] * boxPos[0],
-      -spacing[1] * boxPos[1], -spacing[1] * (boxPos[1] - boxSize[1]),
+      -spacing[1] * (boxPos[1] + boxSize[1]), -spacing[1] * boxPos[1],
       spacing[2] * boxPos[2], spacing[2] * (boxPos[2] + boxSize[2]) );
     vtkNew<vtkPolyDataWriter> writer;
     writer->SetFileName( boxFileName.c_str() );
@@ -118,7 +118,7 @@ void writeBox( std::vector< double > boxPos, std::vector< double > boxSize,
       vtkSmartPointer< vtkCubeSource >::New();
     cubeSource->SetBounds(
       -spacing[0] * (boxPos[0] + boxSize[0]), -spacing[0] * boxPos[0],
-      -spacing[1] * boxPos[1], -spacing[1] * (boxPos[1] - boxSize[1]),
+      -spacing[1] * (boxPos[1] + boxSize[1]), -spacing[1] * boxPos[1],
       0, 0);
     vtkNew<vtkPolyDataWriter> writer;
     writer->SetFileName( boxFileName.c_str() );
@@ -194,7 +194,6 @@ int DoIt (int argc, char * argv[])
   typename TubeGroupType::Pointer pTargetTubeGroup = TubeGroupType::New();
 
   pTargetTubeGroup->CopyInformation( pSourceTubeGroup );
-
   // TODO: make CopyInformation of itk::SpatialObject do this
   pTargetTubeGroup->GetObjectToParentTransform()->SetScale(
     pSourceTubeGroup->GetObjectToParentTransform()->GetScale() );
@@ -220,6 +219,9 @@ int DoIt (int argc, char * argv[])
       {
       return EXIT_FAILURE;
       }
+    //Compute Tangent and Normals
+    pCurSourceTube->ComputeTangentAndNormals();
+    //pCurSourceTube->ComputeObjectToWorldTransform();//BUG
     //Point List for TargetTube
     typename TubeType::PointListType TargetPointList;
     //Get points in current source tube

--- a/Applications/ClipTubes/ClipTubes.xml
+++ b/Applications/ClipTubes/ClipTubes.xml
@@ -27,7 +27,7 @@
     </file>
     <double-vector>
       <name>boxCorner</name>
-      <label>Top Left Corner of Bounding Box</label>
+      <label>Bottom Left Corner of Bounding Box</label>
       <description>Required : 3D position from where to start bounding box</description>
       <longflag>boxCorner</longflag>
       <flag>p</flag>

--- a/Applications/ClipTubes/README.md
+++ b/Applications/ClipTubes/README.md
@@ -19,7 +19,7 @@ returns tubes that are contained in the box.
 Where:
 
    -p, --boxCorner <std::vector<double>>
-     (required) 3D vector corresponding to the position of the top
+     (required) 3D vector corresponding to the position of the bottom
      left-hand corner of the bounding box.
 
    -s, --boxSize <std::vector<double>>


### PR DESCRIPTION
This commit enables us to be more precise when we determine if a
tube belongs to the bounding box, by taking into account the tube
orientation in physical space. 
Compare-Test are expected to fail.