### PR TITLE
COMP: Suppress an ITK warning about overflow.

### DIFF
--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -171,6 +171,7 @@ set( CTEST_CUSTOM_WARNING_EXCEPTION
   "[Uu]tilities.gdcm"
   "[Uu]tilities.vxl"
   "[Uu]tilities.itktiff"
+  "[Cc]ore.[Cc]ommon.[Ii]nclude.itkImageRegionConstIteratorWithIndex.hxx*assuming signed overflow does not occur"
 
   # VTK suppressions
   "vtkfreetype"


### PR DESCRIPTION
Suppress Dashboard warning:
TubeTK-Release/ITK/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.hxx:37:5: warning: assuming signed overflow does not occur when assuming that (X + c) < X is always false [-Wstrict-overflow]
