### PR TITLE
BUG: Must pass JSonCpp_LIBRARIES to SlicerExecutionModel 

### DIFF
--- a/CMake/Superbuild/External_SlicerExecutionModel.cmake
+++ b/CMake/Superbuild/External_SlicerExecutionModel.cmake
@@ -39,7 +39,9 @@ endif( DEFINED ${proj}_DIR AND NOT EXISTS ${${proj}_DIR} )
 
 # Set dependency list
 set( ${proj}_DEPENDENCIES "ITK" "JsonCpp" )
-set( ${proj}_DEPENDENCIES_ARGS "-DJsonCpp_DIR:PATH=${JsonCpp_DIR}" )
+set( ${proj}_DEPENDENCIES_ARGS "-DJsonCpp_DIR:PATH=${JsonCpp_DIR}"
+  "-DJsonCpp_LIBRARIES:PATH=${JsonCpp_LIBRARIES}"
+  "-DJsonCpp_INCLUDE_DIRS:PATH=${JsonCpp_INCLUDE_DIRS}" )
 
 # Include dependent projects, if any.
 TubeTKMacroCheckExternalProjectDependency( ${proj} )

--- a/CMake/Superbuild/External_VTK.cmake
+++ b/CMake/Superbuild/External_VTK.cmake
@@ -39,8 +39,7 @@ endif( DEFINED ${proj}_DIR AND NOT EXISTS ${${proj}_DIR} )
 set( ${proj}_DEPENDENCIES "JsonCpp" )
 set( ${proj}_DEPENDENCIES_ARGS "-DJsonCpp_DIR:PATH=${JsonCpp_DIR}"
   "-DJsonCpp_LIBRARIES:PATH=${JsonCpp_LIBRARIES}"
-  "-DJsonCpp_INCLUDE_DIRS:PATH=${JsonCpp_INCLUDE_DIRS}"
-  )
+  "-DJsonCpp_INCLUDE_DIRS:PATH=${JsonCpp_INCLUDE_DIRS}" )
 
 # Include dependent projects, if any.
 TubeTKMacroCheckExternalProjectDependency( ${proj} )


### PR DESCRIPTION
SlicerExecutionModel (like VTK) does not have a robust Find_JsonCpp cmake file.  JsonCpp libraries must be explicitly passed.