### PR TITLE
COMP: Suppress Slicer cmake macro warning regarding unquoted if args

### DIFF
--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -161,6 +161,9 @@ set( CTEST_CUSTOM_WARNING_EXCEPTION
   "GenerateCLP.cxx.*unused"
   "[Ss]licer[Ee]xecution[Mm]odel.*Module.*std.*dll-interface"
 
+  # Slicer
+  "Slicer.CMake.SlicerMacroConfigureGenericCxxModuleTests.*(if)"
+
   # ImageViewer
   "[Ii]mage[Vv]iewer.*sprintf.*unsafe"
 


### PR DESCRIPTION
Policy CMP0054 is not set: Only interpret if() arguments as variables or
  keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  Quoted variables like "KIT_TEST_SRCS" will no longer be dereferenced when
  the policy is set to NEW.  Since the policy is not set the OLD behavior
  will be used.
Call Stack (most recent call first):
  SlicerModules/SpatialObjectsModule/Testing/Cxx/CMakeLists.txt:29 (SlicerMacroConfigureGenericCxxModuleTests)