### PR TITLE
COMP: Remove itksys_stl::string calls

### DIFF
--- a/SlicerModules/SpatialObjectsModule/Logic/vtkSlicerSpatialObjectsLogic.cxx
+++ b/SlicerModules/SpatialObjectsModule/Logic/vtkSlicerSpatialObjectsLogic.cxx
@@ -140,8 +140,8 @@ void vtkSlicerSpatialObjectsLogic
 
     if(storageNode->ReadData(spatialObjectNode) != 0)
       {
-      const itksys_stl::string fname(filename);
-      itksys_stl::string name =
+      const std::string fname(filename);
+      std::string name =
         itksys::SystemTools::GetFilenameWithoutExtension(fname);
       std::string uname(
         this->GetMRMLScene()->GetUniqueNameByString(name.c_str()));


### PR DESCRIPTION
itksys_stl::string has been replaced by std::string in KWSys in ITK [1]. ITK has been updated in Slicer and TubeTK was not compiling when enabling TubeTK_BUILD_WITHIN_SLICER.

[1] https://github.com/InsightSoftwareConsortium/ITK/commit/daf08c37f4e0d9269b0b84911487994b0a81e002