### PR TITLE
BUG: Adapt MinimalPathExtraction version to ITK version

### DIFF
--- a/Applications/SegmentTubeUsingMinimalPath/CMakeLists.txt
+++ b/Applications/SegmentTubeUsingMinimalPath/CMakeLists.txt
@@ -36,25 +36,19 @@ if( NOT( MinimalPathExtraction_DIR OR
 
   endif()
 
-#   if( NOT EXISTS ${MinimalPathExtraction_SOURCE_DIR} )
-#     set( GIT_COMMAND "git" )
-#     set( GIT_CLONE_ARGS "clone" "${MinimalPathExtraction_URL}"
-#       "${MinimalPathExtraction_SOURCE_DIR}" )
-#     add_custom_target( ITKMinimalPathExtractionDownload
-#       COMMAND ${GIT_COMMAND} ${GIT_CLONE_ARGS}
-#       WORKING_DIRECTORY ${TubeTK_BINARY_DIR}
-#       COMMENT "Download ITKMinimalPathExtraction Remote Module" VERBATIM )
-#   endif( NOT EXISTS ${MinimalPathExtraction_SOURCE_DIR} )
-
   #Download MinimalPathExtraction sources
   if( NOT EXISTS ${MinimalPathExtraction_SOURCE_DIR} )
 
     set( GIT_COMMAND "git" )
-    set( GIT_CLONE_ARGS "clone" "${MinimalPathExtraction_URL}"
+    set( GIT_CLONE_ARGS "clone"
+      "${MinimalPathExtraction_URL}"
+      "-b${MinimalPathExtraction_OLD_ITK_SUPPORT}"
+      "--single-branch"
       "${MinimalPathExtraction_SOURCE_DIR}" )
     execute_process( COMMAND  ${GIT_COMMAND} ${GIT_CLONE_ARGS} )
 
   endif( NOT EXISTS ${MinimalPathExtraction_SOURCE_DIR} )
+
 
   # Find ITK
   find_package( ITK REQUIRED )
@@ -82,10 +76,6 @@ if( NOT( MinimalPathExtraction_DIR OR
       ${MinimalPathExtraction_SOURCE_DIR}/include
     ADDITIONAL_SRCS
       ${SRCS} )
-
-#   if( NOT EXISTS ${${proj}_SOURCE_DIR} )
-#     add_dependencies( ${MODULE_NAME} ITKMinimalPathExtractionDownload )
-#   endif( NOT EXISTS ${${proj}_SOURCE_DIR} )
 
 else()
 

--- a/CMake/Superbuild/ExternalProjectsConfig.cmake
+++ b/CMake/Superbuild/ExternalProjectsConfig.cmake
@@ -51,7 +51,9 @@ set( LIBSVM_HASH_OR_TAG 9e2dd8a5fd032b429c07ce2778c8716117812bc5 )
 
 set( MinimalPathExtraction_URL
   ${git_protocol}://github.com/KitwareMedical/ITKMinimalPathExtraction.git )
-set( MinimalPathExtraction_HASH_OR_TAG 51b1c2c97e9f12fb38039e8546612c452b512695 )
+set( MinimalPathExtraction_HASH_OR_TAG a1791f055fa8d5d105b666da092ceeb80c2424bc )
+set( MinimalPathExtraction_OLD_ITK_SUPPORT
+  support-itk-older-v4.9rc01-2015-10-25-611676c )
 
 ###########################################################
 ###########################################################

--- a/CMake/Superbuild/External_MinimalPathExtraction.cmake
+++ b/CMake/Superbuild/External_MinimalPathExtraction.cmake
@@ -32,7 +32,8 @@ if( NOT ITK_VERSION VERSION_GREATER "4.8" )
 
   if( NOT EXISTS ${${proj}_SOURCE_DIR} )
     list( APPEND TubeTK_EXTERNAL_PROJECTS_ARGS
-      -D${proj}_URL:STRING=${${proj}_URL} )
+      -D${proj}_URL:STRING=${${proj}_URL}
+      -D${proj}_OLD_ITK_SUPPORT:STRING=${${proj}_OLD_ITK_SUPPORT} )
   endif( NOT EXISTS ${${proj}_SOURCE_DIR} )
 
   list( APPEND TubeTK_EXTERNAL_PROJECTS_ARGS


### PR DESCRIPTION
This commit fixes Ubuntu and OSX build when a version prior
to ITK 4.9 is used. For those builds to success, a specific
branch of the MinimalPathExtraction repository is cloned.
It also fixes Windows build issues using ITK 4.9 by bumping
the MinimalPathExtraction version.