### PR TITLE
BUG: Update ITK version test to > 4.8.1 and fixed checkout of extension

### DIFF
--- a/Applications/SegmentTubeUsingMinimalPath/CMakeLists.txt
+++ b/Applications/SegmentTubeUsingMinimalPath/CMakeLists.txt
@@ -27,8 +27,8 @@ project( ${MODULE_NAME} )
 list( FIND ITK_MODULES_ENABLED MinimalPathExtraction
   MinimalPathExtraction_ITK )
 
-if( NOT( MinimalPathExtraction_DIR OR
-  ( ${MinimalPathExtraction_ITK} GREATER "-1" ) ) )
+if( NOT( MinimalPathExtraction_DIR ) AND
+  ( ${MinimalPathExtraction_ITK} EQUAL "-1" ) )
 
   if( NOT MinimalPathExtraction_SOURCE_DIR )
 
@@ -36,19 +36,26 @@ if( NOT( MinimalPathExtraction_DIR OR
 
   endif()
 
-  #Download MinimalPathExtraction sources
+  set( ${MODULE_NAME}_DEPENDS "" )
   if( NOT EXISTS ${MinimalPathExtraction_SOURCE_DIR} )
 
     set( GIT_COMMAND "git" )
-    set( GIT_CLONE_ARGS "clone"
-      "${MinimalPathExtraction_URL}"
-      "-b${MinimalPathExtraction_OLD_ITK_SUPPORT}"
-      "--single-branch"
+    set( GIT_CLONE_ARGS "clone" "${MinimalPathExtraction_LOCAL_BUILD_URL}"
       "${MinimalPathExtraction_SOURCE_DIR}" )
-    execute_process( COMMAND  ${GIT_COMMAND} ${GIT_CLONE_ARGS} )
+    add_custom_target( ITKMinimalPathExtractionDownload
+      COMMAND ${GIT_COMMAND} ${GIT_CLONE_ARGS}
+      WORKING_DIRECTORY ${TubeTK_BINARY_DIR}
+      COMMENT "Download ITKMinimalPathExtraction Remote Module" VERBATIM )
+    set( GIT_HASH_ARGS "checkout"
+      "${MinimalPathExtraction_LOCAL_BUILD_HASH_OR_TAG}" )
+    add_custom_target( ITKMinimalPathExtractionHash
+      COMMAND ${GIT_COMMAND} ${GIT_HASH_ARGS}
+      WORKING_DIRECTORY ${MinimalPathExtraction_SOURCE_DIR}
+      DEPENDS ITKMinimalPathExtractionDownload
+      COMMENT "Swith to ITKMinimalPathExtraction Local Hash" VERBATIM )
+    set( ${MODULE_NAME}_DEPENDS "ITKMinimalPathExtractionHash" )
 
   endif( NOT EXISTS ${MinimalPathExtraction_SOURCE_DIR} )
-
 
   # Find ITK
   find_package( ITK REQUIRED )
@@ -58,8 +65,8 @@ if( NOT( MinimalPathExtraction_DIR OR
   include( ${ITK_USE_FILE} )
 
   #Find MinimalPathExtraction additional sources
-  file( GLOB SRCS
-    "${MinimalPathExtraction_SOURCE_DIR}/src/*.cxx" )
+  set( ITKMinimalPathExtraction_SRCS
+    "${MinimalPathExtraction_SOURCE_DIR}/src/itkIterateNeighborhoodOptimizer.cxx" )
 
   SEMMacroBuildCLI(
     NAME ${MODULE_NAME}
@@ -75,7 +82,11 @@ if( NOT( MinimalPathExtraction_DIR OR
       ${TubeTK_SOURCE_DIR}/Base/Numerics
       ${MinimalPathExtraction_SOURCE_DIR}/include
     ADDITIONAL_SRCS
-      ${SRCS} )
+      ${ITKMinimalPathExtraction_SRCS} )
+
+  if( NOT ${${MODULE_NAME}_DEPENDS} EQUAL "" )
+    add_dependencies( ${MODULE_NAME} ${${MODULE_NAME}_DEPENDS} )
+  endif( NOT ${${MODULE_NAME}_DEPENDS} EQUAL "" )
 
 else()
 

--- a/CMake/Superbuild/ExternalProjectsConfig.cmake
+++ b/CMake/Superbuild/ExternalProjectsConfig.cmake
@@ -49,11 +49,17 @@ set( LIBSVM_URL
   ${git_protocol}://github.com/KitwareMedical/libsvm.git )
 set( LIBSVM_HASH_OR_TAG 9e2dd8a5fd032b429c07ce2778c8716117812bc5 )
 
-set( MinimalPathExtraction_URL
+# MinimalPathExtraction - ITK Module
+set( MinimalPathExtraction_ITK_MODULE_URL
+  ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction.git )
+set( MinimalPathExtraction_ITK_MODULE_HASH_OR_TAG
+  aed93f4ac350ee8d0c3411e885fff86095443b7a )
+
+# MinimalPathExtraction - Local Build
+set( MinimalPathExtraction_LOCAL_BUILD_URL
   ${git_protocol}://github.com/KitwareMedical/ITKMinimalPathExtraction.git )
-set( MinimalPathExtraction_HASH_OR_TAG a1791f055fa8d5d105b666da092ceeb80c2424bc )
-set( MinimalPathExtraction_OLD_ITK_SUPPORT
-  support-itk-older-v4.9rc01-2015-10-25-611676c )
+set( MinimalPathExtraction_LOCAL_BUILD_HASH_OR_TAG
+  4f526802b0056258ca1036fbe7e94d53b1458716 )
 
 ###########################################################
 ###########################################################

--- a/CMake/Superbuild/External_MinimalPathExtraction.cmake
+++ b/CMake/Superbuild/External_MinimalPathExtraction.cmake
@@ -22,7 +22,7 @@
 ##############################################################################
 set( proj MinimalPathExtraction )
 
-if( NOT ITK_VERSION VERSION_GREATER "4.8" )
+if( NOT ITK_VERSION VERSION_GREATER "4.8.1" )
 
   list( REMOVE_ITEM TubeTK_DEPENDENCIES ${proj} )
 
@@ -32,14 +32,15 @@ if( NOT ITK_VERSION VERSION_GREATER "4.8" )
 
   if( NOT EXISTS ${${proj}_SOURCE_DIR} )
     list( APPEND TubeTK_EXTERNAL_PROJECTS_ARGS
-      -D${proj}_URL:STRING=${${proj}_URL}
-      -D${proj}_OLD_ITK_SUPPORT:STRING=${${proj}_OLD_ITK_SUPPORT} )
+      -D${proj}_LOCAL_BUILD_URL:STRING=${${proj}_LOCAL_BUILD_URL}
+      -D${proj}_LOCAL_BUILD_HASH_OR_TAG:STRING=${${proj}_LOCAL_BUILD_HASH_OR_TAG} )
   endif( NOT EXISTS ${${proj}_SOURCE_DIR} )
 
   list( APPEND TubeTK_EXTERNAL_PROJECTS_ARGS
     -D${proj}_SOURCE_DIR:PATH=${${proj}_SOURCE_DIR} )
 
 else()
+
   # Make sure this file is included only once.
   get_filename_component( CMAKE_CURRENT_LIST_FILENAME
     ${CMAKE_CURRENT_LIST_FILE} NAME_WE )
@@ -65,8 +66,8 @@ else()
     set( ${proj}_DIR ${CMAKE_BINARY_DIR}/${proj}-build )
 
     ExternalProject_Add( ${proj}
-      GIT_REPOSITORY ${${proj}_URL}
-      GIT_TAG ${${proj}_HASH_OR_TAG}
+      GIT_REPOSITORY ${${proj}_ITK_MODULE_URL}
+      GIT_TAG ${${proj}_ITK_MODULE_HASH_OR_TAG}
       DOWNLOAD_DIR ${${proj}_SOURCE_DIR}
       SOURCE_DIR ${${proj}_SOURCE_DIR}
       BINARY_DIR ${${proj}_DIR}


### PR DESCRIPTION

* Choose source repo and sha for ITKMinimalPathExtraction based on ITK revision
* ITK revision must be > 4.8.1 for building as an external extension in ITK
* Change checkout of extension to a specific sha, instead of a branch, even when ITK <= 4.8.1