### PR TITLE
Remove unused vtk includes

### DIFF
--- a/Applications/ComputeTrainingMask/ComputeTrainingMask.cxx
+++ b/Applications/ComputeTrainingMask/ComputeTrainingMask.cxx
@@ -37,10 +37,6 @@
 #include <itkAddImageFilter.h>
 #include <itkCastImageFilter.h>
 
-#include <vtkPolyDataWriter.h>
-#include <vtkSmartPointer.h>
-#include <vtkNew.h>
-
 template< class TPixel, unsigned int VDimension >
 int DoIt( int argc, char * argv[] );
 

--- a/Applications/TubeTKModules.cmake
+++ b/Applications/TubeTKModules.cmake
@@ -29,6 +29,7 @@ set( TubeTK_${proj}_MODULES
   ComputeImageSimilarityMetrics
   ComputeImageStatistics
   ComputeSegmentTubesParameters
+  ComputeTrainingMask
   ComputeTubeFlyThroughImage
   ComputeTubeGraphProbability
   ComputeTubeMeasures
@@ -96,7 +97,6 @@ if( TubeTK_USE_VTK )
   set( TubeTK_${proj}_VTK_MODULES
     ClipTubes
     ConvertTubesToSurface
-    ComputeTrainingMask
     ComputeTubeTortuosityMeasures
     RegisterUsingSlidingGeometries )
   list( APPEND TubeTK_${proj}_MODULES


### PR DESCRIPTION
ComputeTrainMask.cxx was including VTK headers, but it did not use any VTK functions/classes.   The headers have been removed.  Building ComputeTrainMask is no longer conditional on VTK.