### PR TITLE
Convert tube to tube tree

### DIFF
--- a/Applications/ConvertTubesToTubeTree/itktubeMinimumSpanningTreeVesselConnectivityFilter.h
+++ b/Applications/ConvertTubesToTubeTree/itktubeMinimumSpanningTreeVesselConnectivityFilter.h
@@ -110,6 +110,7 @@ private:
   void ComputeTubeConnectivity( void );
   void VisitTube( TubePointerType pTube );
   void RunMinimumSpanningTree( TubeIdType rootTubeId );
+  void AddRemainingTubes();
 
   struct GraphEdgeType
     {

--- a/Applications/ConvertTubesToTubeTree/itktubeMinimumSpanningTreeVesselConnectivityFilter.hxx
+++ b/Applications/ConvertTubesToTubeTree/itktubeMinimumSpanningTreeVesselConnectivityFilter.hxx
@@ -390,11 +390,15 @@ MinimumSpanningTreeVesselConnectivityFilter< VDimension >
 
   // visit root tube
   VisitTube( rootTube );
-
   // add root to output
   if( m_RemoveOrphanTubes && m_minpqGraphEdge.empty() )
     {
-    return;
+    bool isActualRoot = std::find(m_RootTubeIdList.begin(),
+      m_RootTubeIdList.end(), rootTubeId) != m_RootTubeIdList.end();
+    if( !isActualRoot )
+      {
+      return;
+      }
     }
   outputTubeGroup->AddSpatialObject( rootTube );
 
@@ -531,13 +535,6 @@ MinimumSpanningTreeVesselConnectivityFilter< VDimension >
       epTube.tubeLength =
         ::tube::ComputeTubeLength< TubeType >(
           m_TubeIdToObjectMap[epTube.tubeId] );
-
-      // check if orphan and drop if requested
-      if( m_RemoveOrphanTubes && epTube.outDegree == 0 )
-        {
-        continue;
-        }
-
       maxpqVOutDegree.push( epTube );
       }
     }
@@ -553,12 +550,10 @@ MinimumSpanningTreeVesselConnectivityFilter< VDimension >
       epTube.tubeLength =
         ::tube::ComputeTubeLength< TubeType >(
           m_TubeIdToObjectMap[epTube.tubeId] );
-
       if( m_RemoveOrphanTubes && epTube.outDegree == 0 )
         {
         continue;
         }
-
       maxpqVOutDegree.push( epTube );
       }
     }
@@ -635,7 +630,10 @@ MinimumSpanningTreeVesselConnectivityFilter< VDimension >
 {
   BuildTubeGraph();
   ComputeTubeConnectivity();
-  AddRemainingTubes();
+  if( !m_RemoveOrphanTubes )
+    {
+    AddRemainingTubes();
+    }
 }
 
 template< unsigned int VDimension >


### PR DESCRIPTION
Fixed an issue, the tubes which were not connected to the root tree were not getting added to the output.
A root tube with no children, was considered a orphan and was not added to the output if removeOrphanTubes parameter was set. 