### PR TITLE
BUG: Fix TubeTKNumerics target_link_libraries using Arrayfire

### DIFF
--- a/Base/Numerics/CMakeLists.txt
+++ b/Base/Numerics/CMakeLists.txt
@@ -77,7 +77,7 @@ add_library( TubeTKNumerics STATIC
   ${TubeTK_Base_Numerics_HXX_Files}
   ${TubeTK_Base_Numerics_SRCS} )
 if( TubeTK_USE_GPU_ARRAYFIRE )
-  target_link_libraries( TubeTKNumerics ${ArrayFire_LIBRARIES} )
+  target_link_libraries( TubeTKNumerics PUBLIC ${ArrayFire_LIBRARIES} )
 endif( TubeTK_USE_GPU_ARRAYFIRE )
 target_link_libraries( TubeTKNumerics PUBLIC TubeTKCommon )
 target_include_directories( TubeTKNumerics PUBLIC


### PR DESCRIPTION
This commit adresses the issue thrown when TubeTK_USE_GPU_ARRAYFIRE
is set to ON. Arrayfire libraries were linked to the TubeTKNumerics
target using target_link_libraries without any signature.
Further in the code, TubeTKCommon libraries are linked to the same
target using the PUBLIC signature.
According to https://cmake.org/cmake/help/v3.0/policy/CMP0023.html,
the NEW behavior for CMake policy doesn't allow plain and keyword
signatures.
Adding a PUBLIC target_link_libraries signature for Arrayfire libraries
fixed it.

The error can be found at : https://open.cdash.org/viewBuildError.php?buildid=4228536