### PR TITLE
Optimizer

### DIFF
--- a/Applications/RegisterImages/RegisterImages.cxx
+++ b/Applications/RegisterImages/RegisterImages.cxx
@@ -112,6 +112,14 @@ int DoIt( int argc, char * argv[] )
       reger->SetInitialMethodEnum( RegistrationType::INIT_WITH_LANDMARKS );
       }
     }
+  if( skipEvolutionary )
+    {
+      reger->SetUseEvolutionaryOptimization( false ) ;
+    }
+  else
+    {
+      reger->SetUseEvolutionaryOptimization( true ) ;
+    }
 
   if( initialization == "Landmarks" )
     {

--- a/Applications/RegisterImages/RegisterImages.cxx
+++ b/Applications/RegisterImages/RegisterImages.cxx
@@ -114,11 +114,11 @@ int DoIt( int argc, char * argv[] )
     }
   if( skipEvolutionary )
     {
-      reger->SetUseEvolutionaryOptimization( false ) ;
+    reger->SetUseEvolutionaryOptimization( false ) ;
     }
   else
     {
-      reger->SetUseEvolutionaryOptimization( true ) ;
+    reger->SetUseEvolutionaryOptimization( true ) ;
     }
 
   if( initialization == "Landmarks" )

--- a/Applications/RegisterImages/RegisterImages.cxx
+++ b/Applications/RegisterImages/RegisterImages.cxx
@@ -112,7 +112,7 @@ int DoIt( int argc, char * argv[] )
       reger->SetInitialMethodEnum( RegistrationType::INIT_WITH_LANDMARKS );
       }
     }
-  if( skipEvolutionary )
+  if( skipInitialRandomSearch )
     {
     reger->SetUseEvolutionaryOptimization( false ) ;
     }

--- a/Applications/RegisterImages/RegisterImages.xml
+++ b/Applications/RegisterImages/RegisterImages.xml
@@ -61,12 +61,10 @@
       <description>Save displacement field result from registration</description>
       <default/>
     </image>
-    <boolean>
-      <name>skipEvolutionary</name>
-      <description>Skips the evolutionary optimizer during the registration process and uses only the gradient optimizer</description>
-      <label>Skip Evolutionary</label>
-      <longflag>skipEvolutionary</longflag>
-      <default>false</default>
+      <name>skipInitialRandomSearch</name>
+      <description>Skips initial random search (skips the evolutionary optimizer) during the registration process and uses only the gradient optimizer</description>
+      <label>Skip Initial Random Search</label>
+      <longflag>skipInitialRandomSearch</longflag>
     </boolean>
     <string-enumeration>
       <name>initialization</name>

--- a/Applications/RegisterImages/RegisterImages.xml
+++ b/Applications/RegisterImages/RegisterImages.xml
@@ -61,6 +61,13 @@
       <description>Save displacement field result from registration</description>
       <default/>
     </image>
+    <boolean>
+      <name>skipEvolutionary</name>
+      <description>Skips the evolutionary optimizer during the registration process and uses only the gradient optimizer</description>
+      <label>Skip Evolutionary</label>
+      <longflag>skipEvolutionary</longflag>
+      <default>false</default>
+    </boolean>
     <string-enumeration>
       <name>initialization</name>
       <description>Method to prime the registration process</description>

--- a/Applications/RegisterImages/RegisterImages.xml
+++ b/Applications/RegisterImages/RegisterImages.xml
@@ -61,6 +61,7 @@
       <description>Save displacement field result from registration</description>
       <default/>
     </image>
+    <boolean>
       <name>skipInitialRandomSearch</name>
       <description>Skips initial random search (skips the evolutionary optimizer) during the registration process and uses only the gradient optimizer</description>
       <label>Skip Initial Random Search</label>

--- a/Base/Registration/itkImageToImageRegistrationHelper.h
+++ b/Base/Registration/itkImageToImageRegistrationHelper.h
@@ -277,6 +277,11 @@ public:
   itkBooleanMacro( EnableBSplineRegistration );
 
   // **************
+  // Specify the optimizer
+  // **************
+  itkSetMacro( UseEvolutionaryOptimization, bool );
+  itkGetMacro( UseEvolutionaryOptimization, bool );
+  // **************
   // Specify the expected magnitudes within the transform.  Used to
   //   guide the operating space of the optimizers
   // **************
@@ -504,7 +509,8 @@ private:
   bool m_ReportProgress;
 
   bool m_MinimizeMemory;
-
+  //  Optimizer
+  bool m_UseEvolutionaryOptimization ;
   //  Loaded Tansform
   typename MatrixTransformType::Pointer   m_LoadedMatrixTransform;
   typename BSplineTransformType::Pointer  m_LoadedBSplineTransform;

--- a/Base/Registration/itkImageToImageRegistrationHelper.txx
+++ b/Base/Registration/itkImageToImageRegistrationHelper.txx
@@ -104,7 +104,8 @@ ImageToImageRegistrationHelper<TImage>
   m_ReportProgress = false;
 
   m_MinimizeMemory = false;
-
+  // Optimizer
+  m_UseEvolutionaryOptimization = true ;
   // Loaded
   m_LoadedMatrixTransform = NULL;
   m_LoadedBSplineTransform = NULL;
@@ -437,6 +438,10 @@ ImageToImageRegistrationHelper<TImage>
     typename RigidRegistrationMethodType::Pointer regRigid;
     regRigid = RigidRegistrationMethodType::New();
     regRigid->SetRandomNumberSeed( m_RandomNumberSeed );
+    if( m_EnableInitialRegistration || !m_UseEvolutionaryOptimization )
+      {
+      regRigid->SetUseEvolutionaryOptimization( false );
+      }
     regRigid->SetReportProgress( m_ReportProgress );
     regRigid->SetMovingImage( m_CurrentMovingImage );
     regRigid->SetFixedImage( m_FixedImage );
@@ -586,7 +591,7 @@ ImageToImageRegistrationHelper<TImage>
     regAff->SetMinimizeMemory( m_MinimizeMemory );
     regAff->SetMaxIterations( m_AffineMaxIterations );
     regAff->SetTargetError( m_AffineTargetError );
-    if( m_EnableRigidRegistration )
+    if( m_EnableRigidRegistration || !m_UseEvolutionaryOptimization )
       {
       regAff->SetUseEvolutionaryOptimization( false );
       }
@@ -706,6 +711,10 @@ ImageToImageRegistrationHelper<TImage>
 
     typename BSplineRegistrationMethodType::Pointer regBspline =
       BSplineRegistrationMethodType::New();
+    if( m_EnableAffineRegistration || !m_UseEvolutionaryOptimization )
+      {
+      regBspline->SetUseEvolutionaryOptimization( false );
+      }
     regBspline->SetRandomNumberSeed( m_RandomNumberSeed );
     regBspline->SetReportProgress( m_ReportProgress );
     regBspline->SetFixedImage( m_FixedImage );

--- a/Base/Registration/itkOptimizedImageToImageRegistrationMethod.txx
+++ b/Base/Registration/itkOptimizedImageToImageRegistrationMethod.txx
@@ -436,9 +436,10 @@ OptimizedImageToImageRegistrationMethod<TImage>
     {
     this->Optimize(metric, interpolator);
     }
-  catch( ... )
+  catch( itk::ExceptionObject& exception )
     {
     std::cerr << "Optimization threw an exception." << std::endl;
+    std::cerr << exception << std::endl ;
     }
 
   if( this->GetReportProgress() )


### PR DESCRIPTION
RegisterImages uses two optimizers: First a evolutionary optimizer and then a gradient descent. It was not possible to skip the evolutionary optimizer, but that one was skipped if one was selecting "PipelineAffine" registration. There is now a flag to skip this evolutionary optimizer and the behavior is more consistent accross the different types of registrations.