### PR TITLE
COMP: Fix undefined INT32_MAX global variable

### DIFF
--- a/Applications/SegmentTubeUsingMinimalPath/SegmentTubeUsingMinimalPath.cxx
+++ b/Applications/SegmentTubeUsingMinimalPath/SegmentTubeUsingMinimalPath.cxx
@@ -39,6 +39,7 @@
 #include "itkSpatialObjectWriter.h"
 #include "itktubeRadiusExtractor2.h"
 #include "itkBinaryThresholdImageFilter.h"
+#include "itkNumericTraits.h"
 
 #include "itkSpeedFunctionToPathFilter.h"
 #include "itkSpeedFunctionPathInformation.h"
@@ -65,7 +66,7 @@ IsPointToNear( typename itk::GroupSpatialObject< DimensionT >::Pointer &sourceTu
   typedef itk::VesselTubeSpatialObject< DimensionT >      TubeType;
   typedef itk::VesselTubeSpatialObjectPoint< DimensionT > TubePointType;
 
-  double minDistance = INT32_MAX;
+  double minDistance = itk::NumericTraits<double>::max();
   double nearestPointRadius = 0.0;
 
   typename TubeGroupType::ChildrenListPointer sourceTubeList =


### PR DESCRIPTION
The global variable INT32_MAX was added in PR #569 but it creates an error on Ubuntu 12.04 according to the dashboard. Including <stdint.h> should be enough to fix the issue but because CircleCI doesn't test TubeTk build on Ubuntu 12.04, we'll have to merge and wait for the continuous results.
