### PR TITLE
COMP: Fix ITKTubeTK module testing

### DIFF
--- a/ITKModules/ITKTubeTK/test/CMakeLists.txt
+++ b/ITKModules/ITKTubeTK/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+# This file is empty in order to satisty ITKModuleExternal.cmake requirements
+# when building against a version of ITK 4.9 that does not include the
+# following change :
+# InsightSoftwareConsortium/ITK@2c51c92


### PR DESCRIPTION
This commit adresses the following issue :

```
  Unknown CMake command "itk_add_test"
    (itk_module_kwstyle_test)
    (itk_module_impl)
    ITKModules/ITKTubeTK/CMakeLists.txt:8 (include)
```

It is adding an empty test directory to satisfy `ITKModuleExternal.cmake`
requirements when the ITK version that is used doesn't contain the
patch InsightSoftwareConsortium/ITK@2c51c92.