### PR TITLE
Easier integration of tubetk

### DIFF
--- a/Applications/ConvertTubesToDensityImage/itktubeTubeSpatialObjectToDensityImage.hxx
+++ b/Applications/ConvertTubesToDensityImage/itktubeTubeSpatialObjectToDensityImage.hxx
@@ -33,7 +33,7 @@ TubeSpatialObjectToDensityImage< TDensityImageType, TRadiusImageType,
                                  TTangentImageType >
 ::TubeSpatialObjectToDensityImage( void )
 {
-  for(short i = 0; i < ImageDimension; i++ )
+  for(unsigned int i = 0; i < ImageDimension; i++ )
     {
     m_Size[i] = 0;
     m_Spacing[i] = 1;
@@ -142,7 +142,7 @@ TubeSpatialObjectToDensityImage< TDensityImageType, TRadiusImageType,
       {
       VectorPixelType v = it_vector.Value();
       typename DensityImageType::IndexType index = it_vector.GetIndex();
-      for( int i = 0; i < ImageDimension; i++ )
+      for( unsigned int i = 0; i < ImageDimension; i++ )
         {
         index[i] += v[i];
         }
@@ -167,7 +167,7 @@ TubeSpatialObjectToDensityImage< TDensityImageType, TRadiusImageType,
       {
       VectorPixelType v = it_vector.Value();
       typename DensityImageType::IndexType index = it_vector.GetIndex();
-      for( int i = 0; i < ImageDimension; i++ )
+      for( unsigned int i = 0; i < ImageDimension; i++ )
         {
         index[i] += v[i];
         }

--- a/Base/Filtering/itktubePadImageFilter.hxx
+++ b/Base/Filtering/itktubePadImageFilter.hxx
@@ -90,7 +90,7 @@ PadImageFilter<TInputImage, TOutputImage>
     // increase the size of the output by the size of the kernel
     SizeType size;
     IndexType idx;
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
       {
       long s1 = 0;
       if( m_GreatestPrimeFactor > 1 )
@@ -173,12 +173,12 @@ PadImageFilter<TInputImage, TOutputImage>
   pad0->SetNumberOfThreads( this->GetNumberOfThreads() );
   if( m_PadMethod != NO_PADDING )
     {
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
       {
       s[i] = ir0.GetIndex()[i] - or0.GetIndex()[i];
       }
     pad0->SetPadLowerBound( s );
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
       {
       s[i] = or0.GetSize()[i] -
         ( ir0.GetIndex()[i] - or0.GetIndex()[i] + ir0.GetSize()[i]);

--- a/Base/Filtering/itktubeSmoothingRecursiveGaussianImageFilter.hxx
+++ b/Base/Filtering/itktubeSmoothingRecursiveGaussianImageFilter.hxx
@@ -50,7 +50,7 @@ SmoothingRecursiveGaussianImageFilter< TInputImage, TOutputImage >
   // InPlace will be set conditionally in the GenerateData method.
 
   m_SmoothingFilters.resize( ImageDimension - 1 );
-  for ( int i = 0; i < static_cast< int >( ImageDimension ) - 1; i++ )
+  for ( unsigned int i = 0; i < ImageDimension - 1; i++ )
     {
     m_SmoothingFilters[i] = InternalGaussianFilterType::New();
     m_SmoothingFilters[i]->SetOrder(InternalGaussianFilterType::ZeroOrder);
@@ -64,7 +64,7 @@ SmoothingRecursiveGaussianImageFilter< TInputImage, TOutputImage >
     {
     m_SmoothingFilters[0]->SetInput( m_FirstSmoothingFilter->GetOutput() );
     }
-  for ( int i = 1; i < static_cast< int >( ImageDimension ) - 1; i++ )
+  for ( unsigned int i = 1; i < ImageDimension - 1; i++ )
     {
     m_SmoothingFilters[i]->SetInput(
       m_SmoothingFilters[i - 1]->GetOutput() );
@@ -98,7 +98,7 @@ SmoothingRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 ::SetNumberOfThreads(ThreadIdType nb)
 {
   Superclass::SetNumberOfThreads(nb);
-  for ( int i = 0; i < static_cast< int >( ImageDimension ) - 1; i++ )
+  for ( unsigned int i = 0; i < ImageDimension - 1; i++ )
     {
     m_SmoothingFilters[i]->SetNumberOfThreads(nb);
     }
@@ -148,7 +148,7 @@ SmoothingRecursiveGaussianImageFilter< TInputImage, TOutputImage >
   if ( this->m_Sigma != sigma )
     {
     this->m_Sigma = sigma;
-    for ( int i = 0; i < static_cast< int >( ImageDimension ) - 1; i++ )
+    for ( unsigned int i = 0; i < ImageDimension - 1; i++ )
       {
       m_SmoothingFilters[i]->SetSigma(m_Sigma[i]);
       }
@@ -289,7 +289,7 @@ SmoothingRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 
   // Register the filter with the with progress accumulator using
   // equal weight proportion.
-  for ( int i = 0; i < static_cast< int >( ImageDimension ) - 1; i++ )
+  for ( unsigned int i = 0; i < ImageDimension - 1; i++ )
     {
     progress->RegisterInternalFilter( m_SmoothingFilters[i], 1.0 /
       ( ImageDimension ) );

--- a/Base/Filtering/itktubeStructureTensorRecursiveGaussianImageFilter.hxx
+++ b/Base/Filtering/itktubeStructureTensorRecursiveGaussianImageFilter.hxx
@@ -281,7 +281,7 @@ StructureTensorRecursiveGaussianImageFilter<TInputImage,TOutputImage >
     unsigned int count = 0;
     for( unsigned int j = 0; j < ImageDimension; ++j)
       {
-      for(int k = j; k < ImageDimension; ++k)
+      for(unsigned int k = j; k < ImageDimension; ++k)
         {
         tmp[count++] = itgradient.Get()[j]*itgradient.Get()[k];
         }

--- a/Base/Numerics/itktubeBlurImageFunction.hxx
+++ b/Base/Numerics/itktubeBlurImageFunction.hxx
@@ -77,7 +77,7 @@ BlurImageFunction<TInputImage>
   m_OriginalSpacing  = this->GetInputImage()->GetSpacing();
   if( m_UseRelativeSpacing )
     {
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
       {
       m_Spacing[i] = m_OriginalSpacing[i] / m_OriginalSpacing[0];
       }
@@ -108,14 +108,14 @@ BlurImageFunction<TInputImage>
   m_UseRelativeSpacing = useRelativeSpacing;
   if( m_UseRelativeSpacing )
     {
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
       {
       m_Spacing[i] = m_OriginalSpacing[i] / m_OriginalSpacing[0];
       }
     }
   else
     {
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
       {
       m_Spacing[i] = m_OriginalSpacing[i];
       }
@@ -167,7 +167,7 @@ BlurImageFunction<TInputImage>
     }
   double gfact = -0.5/( m_Scale*m_Scale );
 
-  for( int i=0; i<ImageDimension; i++ )
+  for( unsigned int i=0; i<ImageDimension; i++ )
     {
     m_KernelMax[i] = ( int )( ( m_Scale*m_Extent )/m_Spacing[i] );
     if( m_KernelMax[i]<1 )

--- a/Base/Numerics/itktubeVotingResampleImageFunction.hxx
+++ b/Base/Numerics/itktubeVotingResampleImageFunction.hxx
@@ -90,7 +90,7 @@ VotingResampleImageFunction< TInputImage, TCoordRep >
     this->GetInputImage()->GetRequestedRegion() );
 
   IndexType newIndex;
-  for(int i = 0; i < ImageDimension; i++)
+  for(unsigned int i = 0; i < ImageDimension; i++)
     {
     newIndex[i] = (int)index[i];
     }

--- a/Base/Registration/itkAffineImageToImageRegistrationMethod.txx
+++ b/Base/Registration/itkAffineImageToImageRegistrationMethod.txx
@@ -43,9 +43,9 @@ AffineImageToImageRegistrationMethod<TImage>
               << std::endl;
     }
   unsigned int scaleNum = 0;
-  for( int d1 = 0; d1 < ImageDimension; d1++ )
+  for( unsigned int d1 = 0; d1 < ImageDimension; d1++ )
     {
-    for( int d2 = 0; d2 < ImageDimension; d2++ )
+    for( unsigned int d2 = 0; d2 < ImageDimension; d2++ )
       {
       if( d1 == d2 )
         {
@@ -58,7 +58,7 @@ AffineImageToImageRegistrationMethod<TImage>
       ++scaleNum;
       }
     }
-  for( int d1 = 0; d1 < ImageDimension; d1++ )
+  for( unsigned int d1 = 0; d1 < ImageDimension; d1++ )
     {
     scales[scaleNum] = 1;
     ++scaleNum;

--- a/Base/Registration/itkImageToImageRegistrationHelper.txx
+++ b/Base/Registration/itkImageToImageRegistrationHelper.txx
@@ -623,9 +623,9 @@ ImageToImageRegistrationHelper<TImage>
     typename AffineTransformType::ParametersType scales;
     scales.set_size( ImageDimension * ImageDimension + ImageDimension );
     unsigned int scaleNum = 0;
-    for( int d1 = 0; d1 < ImageDimension; d1++ )
+    for( unsigned int d1 = 0; d1 < ImageDimension; d1++ )
       {
-      for( int d2 = 0; d2 < ImageDimension; d2++ )
+      for( unsigned int d2 = 0; d2 < ImageDimension; d2++ )
         {
         if( d1 == d2 )
           {
@@ -640,7 +640,7 @@ ImageToImageRegistrationHelper<TImage>
         ++scaleNum;
         }
       }
-    for( int d1 = 0; d1 < ImageDimension; d1++ )
+    for( unsigned int d1 = 0; d1 < ImageDimension; d1++ )
       {
       scales[scaleNum] = 1.0 / (
         m_ExpectedOffsetPixelMagnitude * m_FixedImage->GetSpacing()[0]);

--- a/Base/Registration/itkInitialImageToImageRegistrationMethod.txx
+++ b/Base/Registration/itkInitialImageToImageRegistrationMethod.txx
@@ -82,11 +82,11 @@ InitialImageToImageRegistrationMethod<TImage>
       landmarkTransform->SetIdentity();
       landmarkCalc->SetTransform(landmarkTransform);
       landmarkCalc->InitializeTransform();
-      for( int i = 0; i < TImage::ImageDimension; i++ )
+      for( unsigned int i = 0; i < TImage::ImageDimension; i++ )
         {
         center[i] = landmarkTransform->GetCenter()[i];
         offset[i] = landmarkTransform->GetTranslation()[i];
-        for( int j = 0; j < TImage::ImageDimension; j++ )
+        for( unsigned int j = 0; j < TImage::ImageDimension; j++ )
           {
           matrix(i, j) = landmarkTransform->GetMatrix() (i, j);
           }
@@ -109,11 +109,11 @@ InitialImageToImageRegistrationMethod<TImage>
       landmarkTransform->SetIdentity();
       landmarkCalc->SetTransform(landmarkTransform);
       landmarkCalc->InitializeTransform();
-      for( int i = 0; i < TImage::ImageDimension; i++ )
+      for( unsigned int i = 0; i < TImage::ImageDimension; i++ )
         {
         center[i] = landmarkTransform->GetCenter()[i];
         offset[i] = landmarkTransform->GetTranslation()[i];
-        for( int j = 0; j < TImage::ImageDimension; j++ )
+        for( unsigned int j = 0; j < TImage::ImageDimension; j++ )
           {
           matrix(i, j) = landmarkTransform->GetMatrix() (i, j);
           }
@@ -170,7 +170,7 @@ InitialImageToImageRegistrationMethod<TImage>
     Point<double, ImageDimension> movingCenterPoint;
 
     size = this->GetMovingImage()->GetLargestPossibleRegion().GetSize();
-    for( int i = 0; i < ImageDimension; i++ )
+    for( unsigned int i = 0; i < ImageDimension; i++ )
       {
       movingCenterIndex[i] = size[i] / 2;
       }
@@ -192,7 +192,7 @@ InitialImageToImageRegistrationMethod<TImage>
     if( !this->GetUseRegionOfInterest() )
       {
       std::cout << "Init: Using full image extent" << std::endl;
-      for( int i = 0; i < ImageDimension; i++ )
+      for( unsigned int i = 0; i < ImageDimension; i++ )
         {
         fixedCenterIndex[i] = size[i] / 2;
         }
@@ -202,7 +202,7 @@ InitialImageToImageRegistrationMethod<TImage>
     else
       {
       std::cout << "Init: Using region of interest" << std::endl;
-      for( int i = 0; i < ImageDimension; i++ )
+      for( unsigned int i = 0; i < ImageDimension; i++ )
         {
         fixedCenterPoint[i] = ( this->GetRegionOfInterestPoint1()[i]
                                 + this->GetRegionOfInterestPoint2()[i] ) / 2;
@@ -214,7 +214,7 @@ InitialImageToImageRegistrationMethod<TImage>
     Point<double, ImageDimension> movingCenterPoint;
 
     size = this->GetMovingImage()->GetLargestPossibleRegion().GetSize();
-    for( int i = 0; i < ImageDimension; i++ )
+    for( unsigned int i = 0; i < ImageDimension; i++ )
       {
       movingCenterIndex[i] = size[i] / 2;
       }

--- a/Base/Registration/itktubeAnisotropicDiffusiveRegistrationFilter.hxx
+++ b/Base/Registration/itktubeAnisotropicDiffusiveRegistrationFilter.hxx
@@ -137,7 +137,7 @@ AnisotropicDiffusiveRegistrationFilter
   TensorDerivativeImagePointer secondOrder;
   for( int i = 0; i < this->GetNumberOfTerms(); i++ )
     {
-    for( int j = 0; j < ImageDimension; j++ )
+    for( unsigned int j = 0; j < ImageDimension; j++ )
       {
       firstOrder = ScalarDerivativeImageType::New();
       DiffusiveRegistrationFilterUtils::AllocateSpaceForImage( firstOrder, output );
@@ -712,7 +712,7 @@ AnisotropicDiffusiveRegistrationFilter
 
   NormalVectorType normalVector;
   normalVector.Fill( 0.0 );
-  for( int i = 0; i < ImageDimension; i++ )
+  for( unsigned int i = 0; i < ImageDimension; i++ )
     {
     // Create the multiplication vector image
     DeformationFieldPointer normalMultsImage = DeformationFieldType::New();

--- a/Base/Registration/itktubeAnisotropicDiffusiveRegistrationFunction.hxx
+++ b/Base/Registration/itktubeAnisotropicDiffusiveRegistrationFunction.hxx
@@ -379,9 +379,9 @@ AnisotropicDiffusiveRegistrationFunction
       ScalarDerivativeType deformationComponentFirstOrderDerivative
           = deformationComponentFirstOrderDerivativeRegions[term][i].Get();
       itk::Vector< double, ImageDimension > multVector(0.0);
-      for( int row = 0; row < ImageDimension; row++ )
+      for( unsigned int row = 0; row < ImageDimension; row++ )
         {
-        for( int col = 0; col < ImageDimension; col++ )
+        for( unsigned int col = 0; col < ImageDimension; col++ )
           {
           multVector[row]
               += diffusionTensor(row,col) * deformationComponentFirstOrderDerivative[col];

--- a/Base/Registration/itktubeAnisotropicDiffusiveSparseRegistrationFilter.hxx
+++ b/Base/Registration/itktubeAnisotropicDiffusiveSparseRegistrationFilter.hxx
@@ -165,7 +165,7 @@ AnisotropicDiffusiveSparseRegistrationFilter
   int t = 0;
   ScalarDerivativeImagePointer firstOrder = 0;
   TensorDerivativeImagePointer secondOrder = 0;
-  for( int i = 0; i < ImageDimension; i++ )
+  for( unsigned int i = 0; i < ImageDimension; i++ )
     {
     for( int j = 0; j < this->GetNumberOfTerms(); j++ )
       {
@@ -816,14 +816,14 @@ AnisotropicDiffusiveSparseRegistrationFilter
                                  itk::Point< double, ImageDimension> otherPoint ) const
 {
   double relativePoint[ImageDimension];
-  for( int i = 0; i < ImageDimension; i++ )
+  for( unsigned int i = 0; i < ImageDimension; i++ )
     {
     relativePoint[i] = otherPoint[i] - planePoint[i];
     }
 
   double projection1 = 0.0;
   double projection2 = 0.0;
-  for( int i = 0; i < ImageDimension; i++ )
+  for( unsigned int i = 0; i < ImageDimension; i++ )
     {
     projection1 += vcl_pow(relativePoint[i] * tangentVector1[i], 2);
     projection2 += vcl_pow(relativePoint[i] * tangentVector2[i], 2);
@@ -832,14 +832,14 @@ AnisotropicDiffusiveSparseRegistrationFilter
   projection2 = vcl_sqrt( projection2 );
 
   double pointOnPlane[ImageDimension];
-  for( int i = 0; i < ImageDimension; i++ )
+  for( unsigned int i = 0; i < ImageDimension; i++ )
     {
     pointOnPlane[i] = projection1 * tangentVector1[i]
         + projection2 * tangentVector2[i];
     }
 
   double distance = 0.0;
-  for( int i = 0; i < ImageDimension; i++ )
+  for( unsigned int i = 0; i < ImageDimension; i++ )
     {
     distance += vcl_pow( pointOnPlane[i], 2 );
     }
@@ -1136,7 +1136,7 @@ AnisotropicDiffusiveSparseRegistrationFilter
   DeformationVectorType N_l;
   N_l.Fill( 0.0 );
 
-  for( int i = 0; i < ImageDimension; i++ )
+  for( unsigned int i = 0; i < ImageDimension; i++ )
     {
     // Create the multiplication vector image that is shared between the PROPs
     DeformationFieldPointer normalMultsImage = DeformationFieldType::New();
@@ -1154,7 +1154,7 @@ AnisotropicDiffusiveSparseRegistrationFilter
       multVector.Fill( 0.0 );
       N = normalIt.Get();
       A = weightStructuresIt.Get();
-      for( int j = 0; j < ImageDimension; j++ )
+      for( unsigned int j = 0; j < ImageDimension; j++ )
         {
         N_l[j] = N[i][j];
         }
@@ -1167,7 +1167,7 @@ AnisotropicDiffusiveSparseRegistrationFilter
     this->SetMultiplicationVectorImage( PROP_NORMAL, i, normalMultsImage );
     }
 
-  for( int i = 0; i < ImageDimension; i++ )
+  for( unsigned int i = 0; i < ImageDimension; i++ )
     {
     assert( this->GetMultiplicationVectorImage( SMOOTH_TANGENTIAL, i )
             == this->GetMultiplicationVectorImage( SMOOTH_NORMAL, i ) );
@@ -1191,7 +1191,7 @@ AnisotropicDiffusiveSparseRegistrationFilter
   // Conveniently, (NAN_l) is the PROP multiplication vector (for both SMOOTH
   // and PROP), so we don't need to compute it again here
   DeformationVectorImageRegionArrayType NAN_lRegionArray;
-  for( int i = 0; i < ImageDimension; i++ )
+  for( unsigned int i = 0; i < ImageDimension; i++ )
     {
     DeformationFieldPointer propMultImage
         = this->GetMultiplicationVectorImage( PROP_TANGENTIAL, i );
@@ -1223,7 +1223,7 @@ AnisotropicDiffusiveSparseRegistrationFilter
 
   outputRegion.GoToBegin();
   normalDeformationRegion.GoToBegin();
-  for( int i = 0; i < ImageDimension; i++ )
+  for( unsigned int i = 0; i < ImageDimension; i++ )
     {
     NAN_lRegionArray[i].GoToBegin();
     }
@@ -1231,7 +1231,7 @@ AnisotropicDiffusiveSparseRegistrationFilter
   while( !outputRegion.IsAtEnd() )
     {
     u = outputRegion.Get();
-    for( int i = 0; i < ImageDimension; i++ )
+    for( unsigned int i = 0; i < ImageDimension; i++ )
       {
       normalDeformationVector[i] = NAN_lRegionArray[i].Get() * u;
       }
@@ -1252,7 +1252,7 @@ AnisotropicDiffusiveSparseRegistrationFilter
 
     ++outputRegion;
     ++normalDeformationRegion;
-    for( int i = 0; i < ImageDimension; i++ )
+    for( unsigned int i = 0; i < ImageDimension; i++ )
       {
       ++NAN_lRegionArray[i];
       }
@@ -1296,7 +1296,7 @@ AnisotropicDiffusiveSparseRegistrationFilter
       DiffusiveRegistrationFilterUtils::ExtractXYZComponentsFromDeformationField(
             this->GetDeformationComponentImage(i), deformationComponentImageArray );
 
-      for( int j = 0; j < ImageDimension; j++ )
+      for( unsigned int j = 0; j < ImageDimension; j++ )
         {
         this->ComputeDeformationComponentDerivativeImageHelper(
             deformationComponentImageArray[j], i, j, spacing, radius );
@@ -1304,7 +1304,7 @@ AnisotropicDiffusiveSparseRegistrationFilter
       }
     }
 
-  for( int i = 0; i < ImageDimension; i++ )
+  for( unsigned int i = 0; i < ImageDimension; i++ )
     {
     assert( this->GetDeformationComponentFirstOrderDerivative(
         SMOOTH_TANGENTIAL, i )
@@ -1381,7 +1381,7 @@ AnisotropicDiffusiveSparseRegistrationFilter
        ++normalMatrixIt, ++normalVectorIt )
     {
     matrix = normalMatrixIt.Get();
-    for( int i = 0; i < ImageDimension; i++ )
+    for( unsigned int i = 0; i < ImageDimension; i++ )
       {
       vector[i] = matrix(i,dim);
       normalVectorIt.Set( vector );

--- a/Base/Registration/itktubeDiffusiveRegistrationFilter.hxx
+++ b/Base/Registration/itktubeDiffusiveRegistrationFilter.hxx
@@ -370,7 +370,7 @@ DiffusiveRegistrationFilter
     ScalarDerivativeImageArrayType deformationComponentFirstArray;
     TensorDerivativeImageArrayType deformationComponentSecondArray;
     DeformationVectorImageArrayType multiplicationVectorArray;
-    for( int j = 0; j < ImageDimension; j++ )
+    for( unsigned int j = 0; j < ImageDimension; j++ )
       {
       deformationComponentFirstArray[j] = 0;
       deformationComponentSecondArray[j] = 0;
@@ -430,7 +430,7 @@ DiffusiveRegistrationFilter
   m_DeformationComponentImages[GAUSSIAN] = output;
 
   // Setup the first and second order deformation component images
-  for( int i = 0; i < ImageDimension; i++ )
+  for( unsigned int i = 0; i < ImageDimension; i++ )
     {
     m_DeformationComponentFirstOrderDerivativeArrays[GAUSSIAN][i]
         = ScalarDerivativeImageType::New();
@@ -589,7 +589,7 @@ DiffusiveRegistrationFilter
     DiffusiveRegistrationFilterUtils::ExtractXYZComponentsFromDeformationField(
           this->GetDeformationComponentImage(i), deformationComponentImageArray );
 
-    for( int j = 0; j < ImageDimension; j++ )
+    for( unsigned int j = 0; j < ImageDimension; j++ )
       {
       this->ComputeDeformationComponentDerivativeImageHelper(
           deformationComponentImageArray[j], i, j, spacing, radius );

--- a/Base/Segmentation/itktubeCVTImageFilter.hxx
+++ b/Base/Segmentation/itktubeCVTImageFilter.hxx
@@ -187,12 +187,12 @@ CVTImageFilter< TInputImage, TOutputImage >
     indx.Fill(0);
     for(int j=0; j<(int)m_NumberOfCentroids; j++)
       {
-      for(int i=0; i<ImageDimension; i++)
+      for(unsigned int i=0; i<ImageDimension; i++)
         {
         indx[i] = indx[i] + m_Centroids[j][i];
         }
       }
-    for(int i=0; i<ImageDimension; i++)
+    for(unsigned int i=0; i<ImageDimension; i++)
       {
       indx[i] = indx[i] / m_NumberOfCentroids;
       }
@@ -206,7 +206,7 @@ CVTImageFilter< TInputImage, TOutputImage >
   IndexType iIndx;
   for(int j=0; j<(int)m_NumberOfCentroids; j++)
     {
-    for(int i=0; i<ImageDimension; i++)
+    for(unsigned int i=0; i<ImageDimension; i++)
       {
       iIndx[i] = (int)(m_Centroids[j][i]);
       if(iIndx[i] < 0)
@@ -253,7 +253,7 @@ double
 CVTImageFilter< TInputImage, TOutputImage >
 ::ComputeIteration( double & energyDiff)
 {
-  int i;
+  unsigned int i;
   int j;
   int j2;
 
@@ -361,7 +361,7 @@ CVTImageFilter< TInputImage, TOutputImage >
 ::ComputeSample( PointArrayType * sample, unsigned int sampleSize,
                  SamplingMethodEnum samplingMethod )
 {
-  int i;
+  unsigned int i;
   int j;
 
   if( sampleSize < 1 )
@@ -472,7 +472,7 @@ CVTImageFilter< TInputImage, TOutputImage >
                   unsigned int * nearest )
 {
   double dist;
-  int i;
+  unsigned int i;
   int jc;
   int js;
 

--- a/Base/Segmentation/itktubeRidgeExtractor.hxx
+++ b/Base/Segmentation/itktubeRidgeExtractor.hxx
@@ -1627,7 +1627,7 @@ RidgeExtractor<TInputImage>
 
     // Local 1D Ridge
     m_DataSpline->Extreme( pX, &val, ImageDimension-1, lN );
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
       {
       newX[i] = pX[i];
       }
@@ -1827,7 +1827,7 @@ RidgeExtractor<TInputImage>
     TubePointType tmpPoint;
     typename TubePointType::PointType tubeX;
     typename TubePointType::VectorType tubeV;
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
       {
       tubeX[i] = lX[i];
       lT[i] = m_XHEVect( i, ImageDimension-1 );
@@ -1863,7 +1863,7 @@ RidgeExtractor<TInputImage>
       {
       std::cout << "DynamicScale = " << GetScale() << std::endl;
       }
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
       {
       lX[i] = ( lX[i] + newX[i] ) / 2;
       }

--- a/CMake/Superbuild/CMakeLists.txt
+++ b/CMake/Superbuild/CMakeLists.txt
@@ -90,6 +90,7 @@ if( TubeTK_BUILD_APPLICATIONS )
   # Expose the TubeTK_BUILD_* variables to Superbuild
   file( GLOB_RECURSE TubeTK_modules_files "${TubeTK_SOURCE_DIR}/TubeTKModules.cmake" )
   foreach( f ${TubeTK_modules_files} )
+    ExternalProject_Message( ${PROJECT_NAME} "Including ${f}" )
     include( ${f} )
   endforeach( f ${TubeTK_modules_files} )
 endif( TubeTK_BUILD_APPLICATIONS )

--- a/CMake/Superbuild/CMakeLists.txt
+++ b/CMake/Superbuild/CMakeLists.txt
@@ -83,6 +83,18 @@ if( APPLE )
     -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET} )
 endif( APPLE )
 
+#
+# Add applications and modules build options
+#
+if( TubeTK_BUILD_APPLICATIONS )
+  # Expose the TubeTK_BUILD_* variables to Superbuild
+  file( GLOB_RECURSE TubeTK_modules_files "${TubeTK_SOURCE_DIR}/TubeTKModules.cmake" )
+  foreach( f ${TubeTK_modules_files} )
+    include( ${f} )
+  endforeach( f ${TubeTK_modules_files} )
+endif( TubeTK_BUILD_APPLICATIONS )
+
+
 macro(list_conditional_append cond list)
   if(${cond})
     list(APPEND ${list} ${ARGN})

--- a/CMake/Superbuild/CMakeLists.txt
+++ b/CMake/Superbuild/CMakeLists.txt
@@ -138,6 +138,12 @@ list_conditional_append( TubeTK_USE_PYTHON
     -DTubeTK_USE_NUMPY:BOOL=${TubeTK_USE_NUMPY}
     -DTubeTK_USE_PYQTGRAPH:BOOL=${TubeTK_USE_PYQTGRAPH} )
 
+# Append TubeTK_BUILD_MODULE_DEFAULT is has been specified by the user
+if( DEFINED TubeTK_BUILD_MODULE_DEFAULT )
+  list( APPEND TubeTK_EXTERNAL_PROJECTS_ARGS
+    -DTubeTK_BUILD_MODULE_DEFAULT:BOOL=${TubeTK_BUILD_MODULE_DEFAULT} )
+endif()
+
 # Check dependencies.
 set( EXTERNAL_PROJECT_DIR ${TubeTK_SOURCE_DIR}/CMake/Superbuild )
 

--- a/CMake/Superbuild/ExternalProjectsConfig.cmake
+++ b/CMake/Superbuild/ExternalProjectsConfig.cmake
@@ -68,7 +68,7 @@ set( ITKTubeTK_HASH_OR_TAG "")
 set( MinimalPathExtraction_URL
   ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction.git )
 set( MinimalPathExtraction_HASH_OR_TAG
-  aed93f4ac350ee8d0c3411e885fff86095443b7a )
+  c9cdc87db021ff84417518979dd5924565ff5043 )
 
 set( TubeTK_ITK_MODULES
   ITKTubeTK

--- a/CMake/TubeTKMacroAddModules.cmake
+++ b/CMake/TubeTKMacroAddModules.cmake
@@ -54,6 +54,7 @@ macro( TubeTKMacroAddModules )
   # Add Build all modules option
   option( TubeTK_BUILD_ALL_MODULES "Build all TubeTK modules or not" ON )
   mark_as_advanced( TubeTK_BUILD_ALL_MODULES )
+  mark_as_superbuild( TubeTK_BUILD_ALL_MODULES )
 
   # Add option for each module
   if( MY_TubeTK_MODULES )
@@ -65,6 +66,7 @@ macro( TubeTKMacroAddModules )
         TubeTK_BUILD_${module} "Build ${module} or not. This does not take module dependencies into account." OFF
          "NOT TubeTK_BUILD_ALL_MODULES" ON )
       mark_as_advanced( TubeTK_BUILD_${module} )
+      mark_as_superbuild( TubeTK_BUILD_${module} )
 
       if( TubeTK_BUILD_${module} )
         list( APPEND tubetk_modules ${CMAKE_CURRENT_SOURCE_DIR}/${module} )

--- a/CMake/TubeTKMacroAddModules.cmake
+++ b/CMake/TubeTKMacroAddModules.cmake
@@ -23,19 +23,39 @@
 
 # - Macro to add modules in TubeTK.
 # This macro takes a list of modules directory in input.
+#
 # Example:
-# set( My_list_of_modules m1 m2 )
-# include( TubeTKMacroAddModules )
-# TubeTKMacroAddModules( MODULES ${My_list_of_modules} )
+#
+#   set( My_list_of_modules m1 m2 )
+#   include( TubeTKMacroAddModules )
+#   TubeTKMacroAddModules( MODULES ${My_list_of_modules} )
+#
+#
+# TubeTK_BUILD_ALL_MODULES:
 #
 # It adds the option TubeTK_BUILD_ALL_MODULES and a dependent option
 # TubeTK_BUILD_yourmodulename for each given module. This option can then be
 # queried by to know if the user want to build the module or not.
+#
+# By default, there are no "TubeTK_BUILD_yourmodulename" options. Setting
+# TubeTK_BUILD_ALL_MODULES to OFF will make them available.
+#
 # Example (following the example above):
 #
-# if( TubeTK_BUILD_m1 )
-#   # Then I can build m1
-# endif( TubeTK_BUILD_m1 )
+#   if( TubeTK_BUILD_m1 )
+#     # Then I can build m1
+#   endif( TubeTK_BUILD_m1 )
+#
+#
+# TubeTK_BUILD_MODULE_DEFAULT:
+#
+# The default value of "TubeTK_BUILD_yourmodulename"  options will be ON, this
+# can be changed by configuring TukeTK with option TubeTK_BUILD_MODULE_DEFAULT
+# set to OO. Note that option 'TubeTK_BUILD_MODULE_DEFAULT' has to be specified
+# when configuring for the first time (clean build).
+#
+#
+# TubeTK_MODULES:
 #
 # All the modules chosen to be built are added to the TubeTK_MODULES property
 
@@ -51,6 +71,14 @@ macro( TubeTKMacroAddModules )
     "${multiValueArgs}"
     ${ARGN} )
 
+  set( _build_module_default ON )
+  if( DEFINED TubeTK_BUILD_MODULE_DEFAULT )
+    if( TubeTK_BUILD_ALL_MODULES )
+      message( AUTHOR_WARNING "Specifying 'TubeTK_BUILD_MODULE_DEFAULT' is effective only if 'TubeTK_BUILD_ALL_MODULES' is disabled" )
+    endif()
+    set( _build_module_default ${TubeTK_BUILD_MODULE_DEFAULT} )
+  endif()
+
   # Add Build all modules option
   option( TubeTK_BUILD_ALL_MODULES "Build all TubeTK modules or not" ON )
   mark_as_advanced( TubeTK_BUILD_ALL_MODULES )
@@ -62,9 +90,10 @@ macro( TubeTKMacroAddModules )
 
     set( tubetk_modules )
     foreach( module ${MY_TubeTK_MODULES} )
+
       CMAKE_DEPENDENT_OPTION(
         TubeTK_BUILD_${module} "Build ${module} or not. This does not take module dependencies into account." OFF
-         "NOT TubeTK_BUILD_ALL_MODULES" ON )
+         "NOT TubeTK_BUILD_ALL_MODULES" ${_build_module_default} )
       mark_as_advanced( TubeTK_BUILD_${module} )
       mark_as_superbuild( TubeTK_BUILD_${module} )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,14 +445,6 @@ option( TubeTK_USE_SUPERBUILD
 mark_as_advanced( TubeTK_USE_SUPERBUILD )
 
 if( TubeTK_USE_SUPERBUILD )
-  if( TubeTK_BUILD_APPLICATIONS )
-    # Expose the TubeTK_BUILD_* variables to Superbuild
-    file( GLOB_RECURSE TubeTK_modules_files "TubeTKModules.cmake" )
-    foreach( f ${TubeTK_modules_files} )
-      include( ${f} )
-    endforeach( f ${TubeTK_modules_files} )
-  endif( TubeTK_BUILD_APPLICATIONS )
-
   add_subdirectory( "${CMAKE_CURRENT_SOURCE_DIR}/CMake/Superbuild" )
   return()
 endif( TubeTK_USE_SUPERBUILD )

--- a/ITKModules/CMakeLists.txt
+++ b/ITKModules/CMakeLists.txt
@@ -60,8 +60,10 @@ set_directory_properties(PROPERTIES COMPILE_DEFINITIONS "${_definitions}")
 # Check if ITK support building external module.
 set( ITK_WITH_EXTERNAL_MODULE_SUPPORT 1 )
 set( _reason )
-if( NOT ITK_VERSION VERSION_GREATER "4.8.1" )
-  set( _reason "ITK version >= 4.9 is needed and current version is ${ITK_VERSION}" )
+if( ITK_VERSION VERSION_LESS "4.10.0" )
+  # Version of ITK with at least commit InsightSoftwareConsortium/ITK@a766d34 is required
+  # to support building of TubeTK.
+  set( _reason "ITK version >= 4.10 is needed and current version is ${ITK_VERSION}" )
   set( ITK_WITH_EXTERNAL_MODULE_SUPPORT 0 )
 endif()
 if( NOT EXISTS ${ITK_CMAKE_DIR}/ITKModuleMacros.cmake )

--- a/SlicerModules/SpatialObjectsModule/Testing/Cxx/CMakeLists.txt
+++ b/SlicerModules/SpatialObjectsModule/Testing/Cxx/CMakeLists.txt
@@ -24,22 +24,12 @@
 set( KIT qSlicer${MODULE_NAME}Module )
 
 set( KIT_TEST_SRCS qSlicerSpatialObjectsGlyphWidgetTest1.cxx )
-set( KIT_TEST_NAMES qSlicerSpatialObjectsGlyphWidgetTest1 )
-set( KIT_TEST_NAMES_CXX qSlicerSpatialObjectsGlyphWidgetTest1.cxx )
-SlicerMacroConfigureGenericCxxModuleTests( ${MODULE_NAME} KIT_TEST_SRCS KIT_TEST_NAMES KIT_TEST_NAMES_CXX )
 
-set( CMAKE_TESTDRIVER_BEFORE_TESTMAIN "DEBUG_LEAKS_ENABLE_EXIT_ERROR();" )
-create_test_sourcelist( Tests ${KIT}CxxTests.cxx
-  ${KIT_TEST_NAMES_CXX}
-  EXTRA_INCLUDE vtkMRMLDebugLeaksMacro.h )
-list( REMOVE_ITEM Tests ${KIT_TEST_NAMES_CXX} )
-list( APPEND Tests ${KIT_TEST_SRCS} )
+slicerMacroConfigureModuleCxxTestDriver(
+  NAME ${KIT}
+  SOURCES ${KIT_TEST_SRCS}
+  WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
+  )
 
-set( LIBRARY_NAME ${lib_name} )
-
-add_executable( ${KIT}CxxTests ${Tests} )
-target_link_libraries( ${KIT}CxxTests ${KIT} )
-
-foreach( testname ${KIT_TEST_NAMES} )
-  SIMPLE_TEST( ${testname} )
-endforeach( testname ${KIT_TEST_NAMES} )
+simple_test( qSlicerSpatialObjectsGlyphWidgetTest1 )

--- a/SlicerModules/TortuosityModule/Logic/vtkSlicerTortuosityLogic.cxx
+++ b/SlicerModules/TortuosityModule/Logic/vtkSlicerTortuosityLogic.cxx
@@ -284,7 +284,7 @@ bool vtkSlicerTortuosityLogic
   if( ( metricFlag & FilterType::CURVATURE_HISTOGRAM_METRICS ) > 0 )
     {
     // Create the data arrays for the histogram
-    for( int i = 0; i < numberOfBins; i++ )
+    for( unsigned int i = 0; i < numberOfBins; i++ )
       {
       vtkSmartPointer< vtkIntArray > histArray;
       std::ostringstream oss;
@@ -446,7 +446,7 @@ bool vtkSlicerTortuosityLogic
     if( ( metricFlag & FilterType::CURVATURE_HISTOGRAM_METRICS ) > 0 )
       {
       // Get the histogram features
-      for( int i = 0; i < numberOfBins; i++ )
+      for( unsigned int i = 0; i < numberOfBins; i++ )
         {
         m_HistogramArrays[i]->SetValue( tubeNumber,
           filter->GetCurvatureHistogramMetric( i ) );
@@ -465,7 +465,7 @@ bool vtkSlicerTortuosityLogic
     }
   if ( ( metricFlag & FilterType::CURVATURE_HISTOGRAM_METRICS ) > 0 )
     {
-    for ( int i = 0; i < numberOfBins; i++ )
+    for ( unsigned int i = 0; i < numberOfBins; i++ )
       {
       m_HistogramArrays[i]->Modified();
       }


### PR DESCRIPTION
In addition of fixing warnings, this set of changes will:
* allow to build against old version of Slicer
* update `vtkMRMLSpatialObjectsNode` to adapt to backward incompatible change related to `Reset` method