### PR TITLE
COMP: Fix configure error due to unknown "mark_as_superbuild" command

### DIFF
--- a/CMake/TubeTKMacroAddModules.cmake
+++ b/CMake/TubeTKMacroAddModules.cmake
@@ -82,7 +82,9 @@ macro( TubeTKMacroAddModules )
   # Add Build all modules option
   option( TubeTK_BUILD_ALL_MODULES "Build all TubeTK modules or not" ON )
   mark_as_advanced( TubeTK_BUILD_ALL_MODULES )
-  mark_as_superbuild( TubeTK_BUILD_ALL_MODULES )
+  if( TubeTK_USE_SUPERBUILD )
+    mark_as_superbuild( TubeTK_BUILD_ALL_MODULES )
+  endif()
 
   # Add option for each module
   if( MY_TubeTK_MODULES )
@@ -95,7 +97,9 @@ macro( TubeTKMacroAddModules )
         TubeTK_BUILD_${module} "Build ${module} or not. This does not take module dependencies into account." OFF
          "NOT TubeTK_BUILD_ALL_MODULES" ${_build_module_default} )
       mark_as_advanced( TubeTK_BUILD_${module} )
-      mark_as_superbuild( TubeTK_BUILD_${module} )
+      if( TubeTK_USE_SUPERBUILD )
+        mark_as_superbuild( TubeTK_BUILD_${module} )
+      endif()
 
       if( TubeTK_BUILD_${module} )
         list( APPEND tubetk_modules ${CMAKE_CURRENT_SOURCE_DIR}/${module} )


### PR DESCRIPTION
This commit fixes a regression introduced in af33b91 (COMP: Pass
TubeTK_BUILD_ALL_MODULES and TubeTK_BUILD_* to inner build).

Configure error:

```
CMake Error at CMake/TubeTKMacroAddModules.cmake:85 (mark_as_superbuild):
  Unknown CMake command "mark_as_superbuild".
Call Stack (most recent call first):
  Applications/TubeTKModules.cmake:119 (TubeTKMacroAddModules)
  Applications/CMakeLists.txt:28 (include)
```

Reported-by: Stephen Aylward <Stephen.Aylward@kitware.com>