### PR TITLE
BUG: Correction of bugs introduced when merging branch 'fbudin69500-2…

### DIFF
--- a/Applications/RegisterImages/CMakeLists.txt
+++ b/Applications/RegisterImages/CMakeLists.txt
@@ -43,5 +43,5 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/Base/CLI/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES} ITKOptimizers ITKIOTransformBase
-    TubeTKRegistration )
+    TubeTKRegistration TubeCLI)
 

--- a/Base/CLI/tubeCLIHelperFunctions.h
+++ b/Base/CLI/tubeCLIHelperFunctions.h
@@ -28,7 +28,6 @@ limitations under the License.
 
 #include <itkImage.h>
 #include <itkImageIOFactory.h>
-#include <algorithm> 
 
 namespace tube
 {


### PR DESCRIPTION
…d_images'

Merging branch 'fbudin69500-2d_images' introduce a regression: RegisterImages was not compiling anymore because of a missing target library; including <algorithm> is not necessary in tubeCLIHelperFunctions.h.