### PR TITLE
BUG: Fix TubeTKITKInDoxygenGroup test

### DIFF
--- a/ITKModules/TubeTKITK/include/tubeCropImage.h
+++ b/ITKModules/TubeTKITK/include/tubeCropImage.h
@@ -25,6 +25,8 @@
 namespace tube
 {
 /** \class CropImage
+ *
+ *  \ingroup TubeTKITK
  */
 
 template< typename TInputImage, typename TOutputImage >


### PR DESCRIPTION
This commit adresses the issue thrown when building TubeITK inside
the ITK build tree. See [1].
It adds the CropImage class from tubeCropImage.h in the TubeTKITK group.

[1]: https://open.cdash.org/testDetails.php?test=428387946&build=4272919