### PR TITLE
Fix TubeTK build with TubeTK_USE_LIBSVM option set to OFF

### DIFF
--- a/Applications/TubeTKModules.cmake
+++ b/Applications/TubeTKModules.cmake
@@ -52,7 +52,6 @@ set( TubeTK_${proj}_MODULES
   EnhanceContrastUsingPrior
   EnhanceEdgesUsingDiffusion
   EnhanceTubesUsingDiffusion
-  EnhanceTubesUsingDiscriminantAnalysis
   EnhanceUsingDiscriminantAnalysis
   EnhanceUsingNJetDiscriminantAnalysis
   ImageMath
@@ -96,6 +95,14 @@ if( TubeTK_USE_BOOST )
   list( APPEND TubeTK_${proj}_MODULES
     ${TubeTK_${proj}_Boost_MODULES} )
 endif( TubeTK_USE_BOOST )
+
+set( TubeTK_${proj}_LIBSVM_MODULES )
+if( TubeTK_USE_LIBSVM )
+  set( TubeTK_${proj}_LIBSVM_MODULES
+    EnhanceTubesUsingDiscriminantAnalysis )
+  list( APPEND TubeTK_${proj}_MODULES
+    ${TubeTK_${proj}_LIBSVM_MODULES} )
+endif( TubeTK_USE_LIBSVM )
 
 set( TubeTK_${proj}_VTK_MODULES )
 if( TubeTK_USE_VTK )

--- a/Base/IO/CMakeLists.txt
+++ b/Base/IO/CMakeLists.txt
@@ -30,15 +30,19 @@ set( TubeTK_Base_IO_H_Files
   itktubeMetaRidgeSeed.h
   itktubeMetaTubeExtractor.h
   itktubePDFSegmenterParzenIO.h
-  itktubeRidgeSeedFilterIO.h
   itktubeTubeExtractorIO.h 
   itktubeTubeXIO.h )
+if( TubeTK_USE_LIBSVM )
+  list( APPEND TubeTK_Base_IO_H_Files itktubeRidgeSeedFilterIO.h )
+endif( TubeTK_USE_LIBSVM )
 
 set( TubeTK_Base_IO_HXX_Files
   itktubePDFSegmenterParzenIO.hxx
-  itktubeRidgeSeedFilterIO.hxx
   itktubeTubeExtractorIO.hxx 
   itktubeTubeXIO.hxx )
+if( TubeTK_USE_LIBSVM )
+  list( APPEND TubeTK_Base_IO_HXX_Files itktubeRidgeSeedFilterIO.hxx )
+endif( TubeTK_USE_LIBSVM )
 
 set( TubeTK_Base_IO_SRCS
   itktubeMetaClassPDF.cxx

--- a/Base/IO/Testing/CMakeLists.txt
+++ b/Base/IO/Testing/CMakeLists.txt
@@ -33,8 +33,10 @@ include( ${SlicerExecutionModel_USE_FILE} )
 find_package( ITK REQUIRED )
 include( ${ITK_USE_FILE} )
 
-find_package( LIBSVM REQUIRED )
-include_directories( ${LIBSVM_INCLUDE_DIRS} )
+if( TubeTK_USE_LIBSVM )
+  find_package( LIBSVM REQUIRED )
+  include_directories( ${LIBSVM_INCLUDE_DIRS} )
+endif( TubeTK_USE_LIBSVM )
 
 find_package( PythonInterp )
 if( PYTHON_EXECUTABLE )
@@ -65,19 +67,28 @@ set( tubeBaseIOTests_SRCS
   itktubeMetaRidgeSeedTest.cxx
   itktubeMetaTubeExtractorTest.cxx
   itktubePDFSegmenterParzenIOTest.cxx
-  itktubeRidgeSeedFilterIOTest.cxx
   itktubeTubeExtractorIOTest.cxx
   itktubeTubeXIOTest.cxx )
+if( TubeTK_USE_LIBSVM )
+  list( APPEND tubeBaseIOTests_SRCS itktubeRidgeSeedFilterIOTest.cxx )
+endif( TubeTK_USE_LIBSVM )
+
 
 add_executable( tubeBaseIOHeaderTest
   tubeBaseIOHeaderTest.cxx )
 target_link_libraries( tubeBaseIOHeaderTest
   TubeTKIO ${ITK_LIBRARIES} ${LIBSVM_LIBRARIES} )
+if( TubeTK_USE_LIBSVM )
+  target_link_libraries( tubeBaseIOHeaderTest ${LIBSVM_LIBRARIES} )
+endif( TubeTK_USE_LIBSVM )
 
 set( tubeBaseIO_External_Libraries )
 if( TubeTK_USE_GPU_ARRAYFIRE )
   set( tubeBaseIO_External_Libraries ${ArrayFire_LIBRARIES} )
 endif( TubeTK_USE_GPU_ARRAYFIRE )
+if( TubeTK_USE_LIBSVM )
+  set( tubeBaseIO_External_Libraries ${LIBSVM_LIBRARIES} )
+endif( TubeTK_USE_LIBSVM )
 
 set( no_install_option )
 if( NOT TubeTK_INSTALL_DEVELOPMENT )
@@ -97,7 +108,6 @@ SEMMacroBuildCLI(
     TubeTKIO
     ${ITK_LIBRARIES}
     ITKIOMeta
-    ${LIBSVM_LIBRARIES}
   EXECUTABLE_ONLY
   ${no_install_option}
   )

--- a/Base/IO/Testing/tubeBaseIOHeaderTest.cxx
+++ b/Base/IO/Testing/tubeBaseIOHeaderTest.cxx
@@ -21,13 +21,17 @@ limitations under the License.
 
 =========================================================================*/
 
+#include "tubetkConfigure.h"
+
 #include "itktubeMetaClassPDF.h"
 #include "itktubeMetaLDA.h"
 #include "itktubeMetaNJetLDA.h"
 #include "itktubeMetaRidgeSeed.h"
 #include "itktubeMetaTubeExtractor.h"
 #include "itktubePDFSegmenterParzenIO.h"
-#include "itktubeRidgeSeedFilterIO.h"
+#ifdef TubeTK_USE_LIBSVM
+#  include "itktubeRidgeSeedFilterIO.h"
+#endif
 #include "itktubeTubeExtractorIO.h"
 #include "itktubeTubeXIO.h"
 

--- a/Base/IO/Testing/tubeBaseIOPrintTest.cxx
+++ b/Base/IO/Testing/tubeBaseIOPrintTest.cxx
@@ -21,13 +21,17 @@ limitations under the License.
 
 =========================================================================*/
 
+#include "tubetkConfigure.h"
+
 #include "itktubeMetaLDA.h"
 #include "itktubeMetaNJetLDA.h"
 #include "itktubeMetaClassPDF.h"
 #include "itktubeMetaRidgeSeed.h"
 #include "itktubeMetaTubeExtractor.h"
 #include "itktubePDFSegmenterParzenIO.h"
-#include "itktubeRidgeSeedFilterIO.h"
+#ifdef TubeTK_USE_LIBSVM
+#  include "itktubeRidgeSeedFilterIO.h"
+#endif
 #include "itktubeTubeExtractorIO.h"
 #include "itktubeTubeXIO.h"
 
@@ -59,9 +63,11 @@ int tubeBaseIOPrintTest( int tubeNotUsed( argc ), char * tubeNotUsed( argv )[] )
   std::cout << "-------------pdfSegmenterParzenIO" << std::endl;
   pdfSegmenterParzenIO.PrintInfo();
 
+#ifdef TubeTK_USE_LIBSVM
   itk::tube::RidgeSeedFilterIO< ImageType, ImageType > ridgeSeedFilterIO;
   std::cout << "-------------ridgeSeedFilterIO" << std::endl;
   ridgeSeedFilterIO.PrintInfo();
+#endif
 
   itk::tube::TubeExtractorIO< ImageType > tubeExtractorIO;
   std::cout << "-------------tubeExtractorIO" << std::endl;

--- a/Base/IO/Testing/tubeBaseIOTests.cxx
+++ b/Base/IO/Testing/tubeBaseIOTests.cxx
@@ -21,6 +21,8 @@ limitations under the License.
 
 =========================================================================*/
 
+#include "tubetkConfigure.h"
+
 #include "tubeBaseIOTestsCLP.h"
 #include "tubeTestMain.h"
 
@@ -33,7 +35,9 @@ void RegisterTests( void )
   REGISTER_TEST( itktubeMetaRidgeSeedTest );
   REGISTER_TEST( itktubeMetaTubeExtractorTest );
   REGISTER_TEST( itktubePDFSegmenterParzenIOTest );
+#ifdef TubeTK_USE_LIBSVM
   REGISTER_TEST( itktubeRidgeSeedFilterIOTest );
+#endif
   REGISTER_TEST( itktubeTubeExtractorIOTest );
   REGISTER_TEST( itktubeTubeXIOTest );
 }

--- a/Base/Segmentation/CMakeLists.txt
+++ b/Base/Segmentation/CMakeLists.txt
@@ -23,26 +23,34 @@
 
 project( TubeTKSegmentation )
 
-find_package( LIBSVM )
-include_directories( ${LIBSVM_INCLUDE_DIRS} )
+if( TubeTK_USE_LIBSVM )
+  find_package( LIBSVM )
+  include_directories( ${LIBSVM_INCLUDE_DIRS} )
+endif( TubeTK_USE_LIBSVM )
 
 set( TubeTK_Base_Segmentation_H_Files
   itktubePDFSegmenterBase.h
   itktubePDFSegmenterParzen.h
-  itktubePDFSegmenterSVM.h
   itktubeRadiusExtractor2.h
   itktubeRidgeExtractor.h
-  itktubeRidgeSeedFilter.h
   itktubeTubeExtractor.h )
+if( TubeTK_USE_LIBSVM )
+  list( APPEND TubeTK_Base_Segmentation_H_Files
+    itktubePDFSegmenterSVM.h
+    itktubeRidgeSeedFilter.h )
+endif( TubeTK_USE_LIBSVM )
 
 set( TubeTK_Base_Segmentation_HXX_Files
   itktubePDFSegmenterBase.hxx
   itktubePDFSegmenterParzen.hxx
-  itktubePDFSegmenterSVM.hxx
   itktubeRadiusExtractor2.hxx
   itktubeRidgeExtractor.hxx
-  itktubeRidgeSeedFilter.hxx
   itktubeTubeExtractor.hxx )
+if( TubeTK_USE_LIBSVM )
+  list( APPEND TubeTK_Base_Segmentation_HXX_Files
+    itktubePDFSegmenterSVM.hxx
+    itktubeRidgeSeedFilter.hxx )
+endif( TubeTK_USE_LIBSVM )
 
 add_library( ${PROJECT_NAME} INTERFACE )
 

--- a/Base/Segmentation/Testing/CMakeLists.txt
+++ b/Base/Segmentation/Testing/CMakeLists.txt
@@ -51,33 +51,48 @@ set( TEMP ${TubeTK_BINARY_DIR}/Temporary )
 set( tubeBaseSegmentation_SRCS
   tubeBaseSegmentationPrintTest.cxx
   itktubePDFSegmenterParzenTest.cxx
-  itktubePDFSegmenterSVMTest.cxx
   itktubeRadiusExtractor2Test.cxx
   itktubeRadiusExtractor2Test2.cxx
   itktubeRidgeExtractorTest.cxx
   itktubeRidgeExtractorTest2.cxx
-  itktubeRidgeSeedFilterTest.cxx
   itktubeTubeExtractorTest.cxx )
 
-find_package( LIBSVM )
+if( TubeTK_USE_LIBSVM )
+  list( APPEND tubeBaseSegmentation_SRCS 
+    itktubePDFSegmenterSVMTest.cxx
+    itktubeRidgeSeedFilterTest.cxx )
+
+  find_package( LIBSVM REQUIRED )
+  include_directories( ${LIBSVM_INCLUDE_DIRS} )
+endif( TubeTK_USE_LIBSVM )
 
 include_directories(
   ${TubeTK_SOURCE_DIR}/Base/Common
   ${TubeTK_SOURCE_DIR}/Base/Numerics
   ${TubeTK_SOURCE_DIR}/Base/Filtering
-  ${TubeTK_SOURCE_DIR}/Base/Segmentation
-  ${LIBSVM_INCLUDE_DIRS} )
+  ${TubeTK_SOURCE_DIR}/Base/Segmentation )
 
 add_executable( tubeBaseSegmentationHeaderTest
   tubeBaseSegmentationHeaderTest.cxx )
 target_link_libraries( tubeBaseSegmentationHeaderTest
   TubeTKSegmentation TubeTKFiltering TubeTKNumerics TubeTKIO TubeTKCommon
-  ${ITK_LIBRARIES} ${LIBSVM_LIBRARIES} )
+  ${ITK_LIBRARIES} )
+if( TubeTK_USE_LIBSVM )
+  target_link_libraries( tubeBaseSegmentationHeaderTest
+    ${LIBSVM_LIBRARIES} )
+endif( TubeTK_USE_LIBSVM )
 
 set( no_install_option )
 if( NOT TubeTK_INSTALL_DEVELOPMENT )
   set( no_install_option NO_INSTALL )
 endif()
+
+
+set( tubeBaseSegmentationTests_External_Libraries )
+if( TubeTK_USE_LIBSVM )
+  list( APPEND tubeBaseSegmentationTests_External_Libraries
+    ${LIBSVM_LIBRARIES} )
+endif( TubeTK_USE_LIBSVM )
 
 SEMMacroBuildCLI(
   NAME tubeBaseSegmentationTests
@@ -87,7 +102,7 @@ SEMMacroBuildCLI(
   TARGET_LIBRARIES
     TubeCLI TubeTKSegmentation TubeTKFiltering TubeTKNumerics TubeTKIO
     TubeTKCommon ${ITK_LIBRARIES} ITKIOMeta ITKIOSpatialObjects
-    ${LIBSVM_LIBRARIES}
+    ${tubeBaseSegmentationTests_External_Libraries}
   EXECUTABLE_ONLY
   ${no_install_option}
   )
@@ -133,33 +148,37 @@ Midas3FunctionAddTest( NAME itktubePDFSegmenterParzenTest2
       ${TEMP}/itktubePDFSegmenterParzenTest2_mask.mha
       ${TEMP}/itktubePDFSegmenterParzenTest2_labeledFeatureSpace.mha )
 
-Midas3FunctionAddTest( NAME itktubePDFSegmenterSVMTest
-  COMMAND ${BASE_SEGMENTATION_TESTS}
-    --compare MIDAS{itktubePDFSegmenterTest_mask.mha.md5}
-      ${TEMP}/itktubePDFSegmenterSVMTest_mask.mha
-    itktubePDFSegmenterSVMTest
-      MIDAS{ES0015_Large.mha.md5}
-      MIDAS{ES0015_Large.mha.md5}
-      true
-      5.0
-      MIDAS{GDS0015_Large-TrainingMask.mha.md5}
-      ${TEMP}/itktubePDFSegmenterSVMTest_prob0.mha
-      ${TEMP}/itktubePDFSegmenterSVMTest_prob1.mha
-      ${TEMP}/itktubePDFSegmenterSVMTest_mask.mha )
+if( TubeTK_USE_LIBSVM )
 
-Midas3FunctionAddTest( NAME itktubePDFSegmenterSVMTest2
-  COMMAND ${BASE_SEGMENTATION_TESTS}
-    --compare MIDAS{itktubePDFSegmenterTest2_mask.mha.md5}
-      ${TEMP}/itktubePDFSegmenterSVMTest2_mask.mha
-    itktubePDFSegmenterSVMTest
-      MIDAS{im0001.crop.mha.md5}
-      MIDAS{im0001.crop.contrast.mha.md5}
-      false
-      0.4
-      MIDAS{im0001.vk.mask.crop.mha.md5}
-      ${TEMP}/itktubePDFSegmenterSVMTest2_prob0.mha
-      ${TEMP}/itktubePDFSegmenterSVMTest2_prob1.mha
-      ${TEMP}/itktubePDFSegmenterSVMTest2_mask.mha )
+  Midas3FunctionAddTest( NAME itktubePDFSegmenterSVMTest
+    COMMAND ${BASE_SEGMENTATION_TESTS}
+      --compare MIDAS{itktubePDFSegmenterTest_mask.mha.md5}
+        ${TEMP}/itktubePDFSegmenterSVMTest_mask.mha
+      itktubePDFSegmenterSVMTest
+        MIDAS{ES0015_Large.mha.md5}
+        MIDAS{ES0015_Large.mha.md5}
+        true
+        5.0
+        MIDAS{GDS0015_Large-TrainingMask.mha.md5}
+        ${TEMP}/itktubePDFSegmenterSVMTest_prob0.mha
+        ${TEMP}/itktubePDFSegmenterSVMTest_prob1.mha
+        ${TEMP}/itktubePDFSegmenterSVMTest_mask.mha )
+
+  Midas3FunctionAddTest( NAME itktubePDFSegmenterSVMTest2
+    COMMAND ${BASE_SEGMENTATION_TESTS}
+      --compare MIDAS{itktubePDFSegmenterTest2_mask.mha.md5}
+        ${TEMP}/itktubePDFSegmenterSVMTest2_mask.mha
+      itktubePDFSegmenterSVMTest
+        MIDAS{im0001.crop.mha.md5}
+        MIDAS{im0001.crop.contrast.mha.md5}
+        false
+        0.4
+        MIDAS{im0001.vk.mask.crop.mha.md5}
+        ${TEMP}/itktubePDFSegmenterSVMTest2_prob0.mha
+        ${TEMP}/itktubePDFSegmenterSVMTest2_prob1.mha
+        ${TEMP}/itktubePDFSegmenterSVMTest2_mask.mha )
+
+endif( TubeTK_USE_LIBSVM )
 
 Midas3FunctionAddTest( NAME itktubeRidgeExtractorTest
   COMMAND ${BASE_SEGMENTATION_TESTS}
@@ -193,15 +212,19 @@ Midas3FunctionAddTest( NAME itktubeTubeExtractorTest
       MIDAS{Branch.n010.sub.mha.md5}
       MIDAS{Branch-truth.tre.md5} )
 
-Midas3FunctionAddTest( NAME itktubeRidgeSeedFilterTest
-  COMMAND ${BASE_SEGMENTATION_TESTS}
-    --compareNumberOfPixelsTolerance 100
-    --compare MIDAS{itktubeRidgeSeedFilterTest_Output.mha.md5}
-      ${TEMP}/itktubeRidgeSeedFilterTest_Output.mha
-    itktubeRidgeSeedFilterTest
-      MIDAS{im0001.crop.contrast.mha.md5}
-      MIDAS{im0001.vk.maskRidge.crop.mha.md5}
-      255 127
-      ${TEMP}/itktubeRidgeSeedFilterTest_Feature0Image.mha
-      ${TEMP}/itktubeRidgeSeedFilterTest_Output.mha
-      ${TEMP}/itktubeRidgeSeedFilterTest_MaxScale.mha )
+if( TubeTK_USE_LIBSVM )
+
+  Midas3FunctionAddTest( NAME itktubeRidgeSeedFilterTest
+    COMMAND ${BASE_SEGMENTATION_TESTS}
+      --compareNumberOfPixelsTolerance 100
+      --compare MIDAS{itktubeRidgeSeedFilterTest_Output.mha.md5}
+        ${TEMP}/itktubeRidgeSeedFilterTest_Output.mha
+      itktubeRidgeSeedFilterTest
+        MIDAS{im0001.crop.contrast.mha.md5}
+        MIDAS{im0001.vk.maskRidge.crop.mha.md5}
+        255 127
+        ${TEMP}/itktubeRidgeSeedFilterTest_Feature0Image.mha
+        ${TEMP}/itktubeRidgeSeedFilterTest_Output.mha
+        ${TEMP}/itktubeRidgeSeedFilterTest_MaxScale.mha )
+
+endif( TubeTK_USE_LIBSVM )

--- a/Base/Segmentation/Testing/tubeBaseSegmentationHeaderTest.cxx
+++ b/Base/Segmentation/Testing/tubeBaseSegmentationHeaderTest.cxx
@@ -21,12 +21,18 @@ limitations under the License.
 
 =========================================================================*/
 
+#include "tubetkConfigure.h"
+
 #include "itktubePDFSegmenterBase.h"
 #include "itktubePDFSegmenterParzen.h"
-#include "itktubePDFSegmenterSVM.h"
+#ifdef TubeTK_USE_LIBSVM
+#  include "itktubePDFSegmenterSVM.h"
+#endif
 #include "itktubeRadiusExtractor2.h"
 #include "itktubeRidgeExtractor.h"
-#include "itktubeRidgeSeedFilter.h"
+#ifdef TubeTK_USE_LIBSVM
+#  include "itktubeRidgeSeedFilter.h"
+#endif
 #include "itktubeTubeExtractor.h"
 
 #include <iostream>

--- a/Base/Segmentation/Testing/tubeBaseSegmentationPrintTest.cxx
+++ b/Base/Segmentation/Testing/tubeBaseSegmentationPrintTest.cxx
@@ -21,11 +21,17 @@ limitations under the License.
 
 =========================================================================*/
 
+#include "tubetkConfigure.h"
+
 #include "itktubePDFSegmenterParzen.h"
-#include "itktubePDFSegmenterSVM.h"
+#ifdef TubeTK_USE_LIBSVM
+#  include "itktubePDFSegmenterSVM.h"
+#endif
 #include "itktubeRadiusExtractor2.h"
 #include "itktubeRidgeExtractor.h"
-#include "itktubeRidgeSeedFilter.h"
+#ifdef TubeTK_USE_LIBSVM
+#  include "itktubeRidgeSeedFilter.h"
+#endif
 #include "itktubeTubeExtractor.h"
 
 #include <itkImage.h>
@@ -42,11 +48,13 @@ int tubeBaseSegmentationPrintTest( int itkNotUsed( argc ),
   std::cout << "-------------itktubePDFSegmenterParzen" << pdfSegmenterParzen
     << std::endl;
 
+#ifdef TubeTK_USE_LIBSVM
   itk::tube::PDFSegmenterSVM< ImageType, ImageType >::Pointer
     pdfSegmenterSVM = itk::tube::PDFSegmenterSVM< ImageType,
       ImageType >::New();
   std::cout << "-------------itktubePDFSegmenterSVM" << pdfSegmenterSVM
     << std::endl;
+#endif
 
   itk::tube::RadiusExtractor2< ImageType >::Pointer
     radius2Object = itk::tube::RadiusExtractor2< ImageType >::New();
@@ -58,11 +66,13 @@ int tubeBaseSegmentationPrintTest( int itkNotUsed( argc ),
   std::cout << "-------------itktubeRidgeExtractor" << ridgeObject
     << std::endl;
 
+#ifdef TubeTK_USE_LIBSVM
   itk::tube::RidgeSeedFilter< ImageType, CharImageType >::Pointer
     seedObject = itk::tube::RidgeSeedFilter< ImageType,
     CharImageType >::New();
   std::cout << "-------------itktubeRidgeSeedFilter" << seedObject
     << std::endl;
+#endif
 
   itk::tube::TubeExtractor< ImageType >::Pointer tubeObject =
     itk::tube::TubeExtractor< ImageType >::New();

--- a/Base/Segmentation/Testing/tubeBaseSegmentationTests.cxx
+++ b/Base/Segmentation/Testing/tubeBaseSegmentationTests.cxx
@@ -23,6 +23,7 @@ limitations under the License.
 
 #include "tubeBaseSegmentationTestsCLP.h"
 #include "tubeTestMain.h"
+#include "tubetkConfigure.h"
 
 #include <iostream>
 
@@ -30,10 +31,14 @@ void RegisterTests( void )
 {
   REGISTER_TEST( tubeBaseSegmentationPrintTest );
   REGISTER_TEST( itktubePDFSegmenterParzenTest );
+#ifdef TubeTK_USE_LIBSVM
   REGISTER_TEST( itktubePDFSegmenterSVMTest );
+#endif
   REGISTER_TEST( itktubeRidgeExtractorTest );
   REGISTER_TEST( itktubeRidgeExtractorTest2 );
+#ifdef TubeTK_USE_LIBSVM
   REGISTER_TEST( itktubeRidgeSeedFilterTest );
+#endif
   REGISTER_TEST( itktubeRadiusExtractor2Test );
   REGISTER_TEST( itktubeRadiusExtractor2Test2 );
   REGISTER_TEST( itktubeTubeExtractorTest );

--- a/CMake/tubetkConfigure.h.in
+++ b/CMake/tubetkConfigure.h.in
@@ -27,5 +27,7 @@ limitations under the License.
 // this gets defined if use set TUBETK_USE_GPU_ARRAYFIRE to ON
 #cmakedefine TubeTK_USE_GPU_ARRAYFIRE
 
+// this gets defined if use set TubeTK_USE_LIBSVM to ON
+#cmakedefine TubeTK_USE_LIBSVM
 
 #endif // __tubetkConfigure_h


### PR DESCRIPTION
This commit fixes a regression introduced in 55a11b4 (ENH: Initial
implementation of LIBSVM-based PDFSegmenter)