### PR TITLE
STYLE: Modernize vcl_ to std::

### DIFF
--- a/Applications/AtlasBuilderUsingIntensity/itktubeMeanAndSigmaImageBuilder.hxx
+++ b/Applications/AtlasBuilderUsingIntensity/itktubeMeanAndSigmaImageBuilder.hxx
@@ -171,10 +171,10 @@ void MeanAndSigmaImageBuilder< TInputImageType,
         ProcessPixelType variance =
           ( sumSqr - ( (sum * sum ) / number )) / (number - 1);
 
-        // If Standard Deviation Calc. s = vcl_sqrt(s^2)
+        // If Standard Deviation Calc. s = std::sqrt(s^2)
         if( isStdDeviation )
           {
-          variance = vcl_sqrt(variance);
+          variance = std::sqrt(variance);
           }
         it_dev.Set( (OutputSigmaPixelType) variance );
         it_mean.Set( (OutputMeanPixelType)

--- a/Applications/ComputeImageStatistics/ComputeImageStatistics.cxx
+++ b/Applications/ComputeImageStatistics/ComputeImageStatistics.cxx
@@ -310,7 +310,7 @@ int DoIt( int argc, char * argv[] )
       }
     if( compCount[ i ] > 0 )
       {
-      compStdDev[ i ] = vcl_sqrt( ( compStdDev[ i ]
+      compStdDev[ i ] = std::sqrt( ( compStdDev[ i ]
         - ( ( compMean[ i ] * compMean[ i ] ) / compCount[ i ] ) )
         / ( compCount[ i ] - 1 ) );
       compMean[ i ] /= compCount[ i ];

--- a/Applications/DeblendTomosynthesisSlicesUsingPrior/DeblendTomosynthesisSlicesUsingPrior.cxx
+++ b/Applications/DeblendTomosynthesisSlicesUsingPrior/DeblendTomosynthesisSlicesUsingPrior.cxx
@@ -204,11 +204,11 @@ public:
       double mean255 = sum255/count255;
       double meanNot = sumNot/countNot;
 
-      double stdDev255 = vcl_sqrt( sums255/count255 - mean255*mean255 );
-      double stdDevNot = vcl_sqrt( sumsNot/countNot - meanNot*meanNot );
+      double stdDev255 = std::sqrt( sums255/count255 - mean255*mean255 );
+      double stdDevNot = std::sqrt( sumsNot/countNot - meanNot*meanNot );
 
       result = - vnl_math_abs(mean255 - meanNot)
-        / vcl_sqrt( stdDev255 * stdDevNot );
+        / std::sqrt( stdDev255 * stdDevNot );
       }
 
     std::cout << ++m_CallsToGetValue << " : "
@@ -431,11 +431,11 @@ public:
       double mean255 = sum255/count255;
       double meanNot = sumNot/countNot;
 
-      double stdDev255 = vcl_sqrt( sums255/count255 - mean255*mean255 );
-      double stdDevNot = vcl_sqrt( sumsNot/countNot - meanNot*meanNot );
+      double stdDev255 = std::sqrt( sums255/count255 - mean255*mean255 );
+      double stdDevNot = std::sqrt( sumsNot/countNot - meanNot*meanNot );
 
       result = - vnl_math_abs(mean255 - meanNot)
-        / vcl_sqrt( stdDev255 * stdDevNot );
+        / std::sqrt( stdDev255 * stdDevNot );
       }
 
     std::cout << ++m_CallsToGetValue << " : "

--- a/Applications/EnhanceContrastUsingPrior/EnhanceContrastUsingPrior.cxx
+++ b/Applications/EnhanceContrastUsingPrior/EnhanceContrastUsingPrior.cxx
@@ -218,12 +218,12 @@ public:
     if( countObj > 0 )
       {
       meanObj = sumObj/countObj;
-      stdDevObj = vcl_sqrt( sumsObj/countObj - meanObj*meanObj );
+      stdDevObj = std::sqrt( sumsObj/countObj - meanObj*meanObj );
       }
     if( countBkg > 0 )
       {
       meanBkg = sumBkg/countBkg;
-      stdDevBkg = vcl_sqrt( sumsBkg/countBkg - stdDevBkg*stdDevBkg );
+      stdDevBkg = std::sqrt( sumsBkg/countBkg - stdDevBkg*stdDevBkg );
       }
 
     double dp = vnl_math_abs(meanObj - meanBkg) / (stdDevObj * stdDevBkg);

--- a/Applications/SimulateAcquisitionArtifactsUsingPrior/tubeCompareImageWithPrior.hxx
+++ b/Applications/SimulateAcquisitionArtifactsUsingPrior/tubeCompareImageWithPrior.hxx
@@ -798,7 +798,7 @@ CompareImageWithPrior< TPixel, TDimension>
 
   if( m_GoF>0 && count>0 )
     {
-    m_GoF = -vcl_sqrt( m_GoF/count );
+    m_GoF = -std::sqrt( m_GoF/count );
     }
 
   if( m_TimeCollector )

--- a/Base/Filtering/Testing/itktubeStructureTensorRecursiveGaussianImageFilterTestNew.cxx
+++ b/Base/Filtering/Testing/itktubeStructureTensorRecursiveGaussianImageFilterTestNew.cxx
@@ -85,7 +85,7 @@ int itktubeStructureTensorRecursiveGaussianImageFilterTestNew( int argc, char * 
     ImageType::IndexType index = it.GetIndex();
     ImageType::PointType point;
     inImage->TransformIndexToPhysicalPoint(index, point);
-    it.Set(static_cast<ImageType::PixelType>(vcl_sin(point[0]))); //sinx
+    it.Set(static_cast<ImageType::PixelType>(std::sin(point[0]))); //sinx
     }
 
   typedef itk::ImageFileWriter<ImageType>        WriterType;
@@ -111,7 +111,7 @@ int itktubeStructureTensorRecursiveGaussianImageFilterTestNew( int argc, char * 
     ImageType::IndexType index = pt.GetIndex();
     ImageType::PointType point;
     prodImage->TransformIndexToPhysicalPoint(index, point);
-    double cosValue = vcl_cos(point[0]);
+    double cosValue = std::cos(point[0]);
     pt.Set(static_cast<ImageType::PixelType>(cosValue*cosValue)); //cosx*cosx
     }
 

--- a/Base/Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter.hxx
+++ b/Base/Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter.hxx
@@ -223,13 +223,13 @@ AnisotropicCoherenceEnhancingDiffusionImageFilter<TInputImage, TOutputImage>
       }
     else
       {
-      double kappa = vcl_pow( ((float) (eigenValue[middleEigenValueIndex]) /
+      double kappa = std::pow( ((float) (eigenValue[middleEigenValueIndex]) /
         ( m_Alpha + eigenValue[smallestEigenValueIndex])), 4.0);
 
       double contrastParameterLambdaCSquare = m_ContrastParameterLambdaC
         * m_ContrastParameterLambdaC;
 
-      double expVal = vcl_exp((-1.0 * (vcl_log( 2.0)
+      double expVal = std::exp((-1.0 * (std::log( 2.0)
         * contrastParameterLambdaCSquare )/kappa ));
       Lambda3 = m_Alpha + (1.0 - m_Alpha)*expVal;
 

--- a/Base/Filtering/itktubeAnisotropicDiffusionTensorFunction.hxx
+++ b/Base/Filtering/itktubeAnisotropicDiffusionTensorFunction.hxx
@@ -330,7 +330,7 @@ AnisotropicDiffusionTensorFunction<TImageType>
 
   // TODO plus 1?
   double ratio
-      = minSpacing / vcl_pow(2.0, static_cast<double>(ImageDimension) + 1);
+      = minSpacing / std::pow(2.0, static_cast<double>(ImageDimension) + 1);
 
   if( m_TimeStep > ratio )
     {

--- a/Base/Filtering/itktubeAnisotropicEdgeEnhancementDiffusionImageFilter.hxx
+++ b/Base/Filtering/itktubeAnisotropicEdgeEnhancementDiffusionImageFilter.hxx
@@ -252,7 +252,7 @@ AnisotropicEdgeEnhancementDiffusionImageFilter<TInputImage, TOutputImage>
         * gradientMagnitude;
       double ratio = (gradientMagnitudeSquare) /
         (m_ContrastParameterLambdaE*m_ContrastParameterLambdaE);
-      double expVal = vcl_exp( (-1.0 * m_ThresholdParameterC)/(vcl_pow( ratio,
+      double expVal = std::exp( (-1.0 * m_ThresholdParameterC)/(std::pow( ratio,
         4.0 )));
       Lambda1 = 1.0 - expVal;
       }

--- a/Base/Filtering/itktubeAnisotropicHybridDiffusionImageFilter.hxx
+++ b/Base/Filtering/itktubeAnisotropicHybridDiffusionImageFilter.hxx
@@ -256,7 +256,7 @@ AnisotropicHybridDiffusionImageFilter<TInputImage, TOutputImage>
         * gradientMagnitude;
       double ratio = (gradientMagnitudeSquare) /
                (m_ContrastParameterLambdaEED*m_ContrastParameterLambdaEED);
-      double expVal = vcl_exp( (-1.0 * m_ThresholdParameterC)/(vcl_pow( ratio,
+      double expVal = std::exp( (-1.0 * m_ThresholdParameterC)/(std::pow( ratio,
         4.0 )));
       LambdaEED1 = 1.0 - expVal;
       }
@@ -284,14 +284,14 @@ AnisotropicHybridDiffusionImageFilter<TInputImage, TOutputImage>
     else
       {
       double kappa =
-       vcl_pow( ((float) (eigenValue[middleEigenValueIndex]) /
+       std::pow( ((float) (eigenValue[middleEigenValueIndex]) /
                 ( m_Alpha + eigenValue[smallestEigenValueIndex])),
                4.0);
 
       double contrastParameterLambdaCEDSquare
         = m_ContrastParameterLambdaCED * m_ContrastParameterLambdaCED;
 
-      double expVal = vcl_exp((-1.0 * (vcl_log( 2.0)
+      double expVal = std::exp((-1.0 * (std::log( 2.0)
         * contrastParameterLambdaCEDSquare )/kappa ));
       LambdaCED3 = m_Alpha + (1.0 - m_Alpha)*expVal;
       }
@@ -311,10 +311,10 @@ AnisotropicHybridDiffusionImageFilter<TInputImage, TOutputImage>
       * (xi - vnl_math_abs(xi)) - 2.0 * eigenValue[smallestEigenValueIndex] );
 
 
-    double denominator = 2.0 * vcl_pow( m_ContrastParameterLambdaHybrid,
+    double denominator = 2.0 * std::pow( m_ContrastParameterLambdaHybrid,
       4.0 );
 
-    double epsilon = vcl_exp(numerator/denominator);
+    double epsilon = std::exp(numerator/denominator);
 
     Lambda1 = (1 - epsilon ) * LambdaCED1 + epsilon*LambdaEED1;
     Lambda2 = (1 - epsilon ) * LambdaCED2 + epsilon*LambdaEED2;

--- a/Base/Filtering/itktubeCVTImageFilter.hxx
+++ b/Base/Filtering/itktubeCVTImageFilter.hxx
@@ -323,7 +323,7 @@ ComputeIteration( double & energyDiff )
         dist = ( m_Centroids[j2][i] - batch[j][i] )
           * ( m_Centroids[j2][i] - batch[j][i] );
         }
-      energy = energy + vcl_sqrt( dist );
+      energy = energy + std::sqrt( dist );
       count[j2] = count[j2] + 1;
       }
     }
@@ -396,7 +396,7 @@ ComputeSample( PointArrayType * sample, unsigned int sampleSize,
         len = len * m_InputImageSize[i];
         }
       double factor = len / ( double )sampleSize;
-      factor = vcl_pow( factor, 1.0 / ImageDimension );
+      factor = std::pow( factor, 1.0 / ImageDimension );
       int * gridSize = new int[ImageDimension];
       len = 1;
       for( unsigned int i = 0; i < ImageDimension; i++ )

--- a/Base/Filtering/itktubeGaussianDerivativeImageSource.hxx
+++ b/Base/Filtering/itktubeGaussianDerivativeImageSource.hxx
@@ -148,7 +148,7 @@ GaussianDerivativeImageSource< TOutputImage >
                              outputPtr->GetRequestedRegion()
                              .GetNumberOfPixels() );
   double prefixDenom = 1.0;
-  const double squareRootOfTwoPi = vcl_sqrt(2.0 * vnl_math::pi);
+  const double squareRootOfTwoPi = std::sqrt(2.0 * vnl_math::pi);
   for ( unsigned int i = 0; i < TOutputImage::ImageDimension; i++ )
     {
     prefixDenom *= m_Sigmas[i] * squareRootOfTwoPi;
@@ -167,9 +167,9 @@ GaussianDerivativeImageSource< TOutputImage >
       {
       if( m_Orders[i] != 0 )
         {
-        prefixDenom *= vcl_pow( m_Sigmas[i], 2*m_Orders[i] )
-          / (vcl_pow( ( -(evalPoint[i] - m_Mean[i]) ), m_Orders[i] )
-             - ( m_Orders[i] == 2 ? vcl_pow(m_Sigmas[1], m_Orders[i]) : 0));
+        prefixDenom *= std::pow( m_Sigmas[i], 2*m_Orders[i] )
+          / (std::pow( ( -(evalPoint[i] - m_Mean[i]) ), m_Orders[i] )
+             - ( m_Orders[i] == 2 ? std::pow(m_Sigmas[1], m_Orders[i]) : 0));
         }
       }
     double suffixExp = 0;
@@ -180,8 +180,8 @@ GaussianDerivativeImageSource< TOutputImage >
                    / ( 2 * m_Sigmas[i] * m_Sigmas[i] );
       }
 
-    double value = ( 1 / prefixDenom ) * vcl_exp( -suffixExp );
-    total += vcl_abs( value );
+    double value = ( 1 / prefixDenom ) * std::exp( -suffixExp );
+    total += std::abs( value );
 
     // Set the pixel value to the function value
     outIt.Set( ( typename TOutputImage::PixelType )value );

--- a/Base/Filtering/itktubePadImageFilter.h
+++ b/Base/Filtering/itktubePadImageFilter.h
@@ -162,7 +162,7 @@ private:
 
   bool isPrime( int n )
     {
-    int last = (int)vcl_sqrt( static_cast<float>( n ) );
+    int last = (int)std::sqrt( static_cast<float>( n ) );
     for( int x=2; x<=last; x++ )
       {
       if( n%x == 0 )

--- a/Base/Filtering/itktubeSheetnessMeasureImageFilter.hxx
+++ b/Base/Filtering/itktubeSheetnessMeasureImageFilter.hxx
@@ -172,13 +172,13 @@ SheetnessMeasureImageFilter< TPixel >
       Rb = vnl_math_abs( l3 + l3 - l2 - l1 ) / l3;
       }
 
-    Rn = vcl_sqrt( l3*l3 + l2*l2 + l1*l1 );
+    Rn = std::sqrt( l3*l3 + l2*l2 + l1*l1 );
 
-    sheetness  =         vcl_exp( - ( Rs * Rs ) /
+    sheetness  =         std::exp( - ( Rs * Rs ) /
         ( 2.0 * m_Alpha * m_Alpha ) );
-    sheetness *= ( 1.0 - vcl_exp( - ( Rb * Rb ) /
+    sheetness *= ( 1.0 - std::exp( - ( Rb * Rb ) /
         ( 2.0 * m_Beta * m_Beta ) ) );
-    sheetness *= ( 1.0 - vcl_exp( - ( Rn * Rn ) /
+    sheetness *= ( 1.0 - std::exp( - ( Rn * Rn ) /
         ( 2.0 * m_Cfactor * m_Cfactor     ) ) );
     oit.Set(static_cast< OutputPixelType >( sheetness));
 

--- a/Base/Filtering/itktubeShrinkWithBlendingImageFilter.h
+++ b/Base/Filtering/itktubeShrinkWithBlendingImageFilter.h
@@ -64,7 +64,7 @@ namespace tube {
 * factor in each dimension. The algorithm implemented is a max over the
 * subsample. The output image size in each dimension is given by:
 *
-* outputSize[j] = max( vcl_floor(inputSize[j]/shrinkFactor[j]), 1 );
+* outputSize[j] = max( std::floor(inputSize[j]/shrinkFactor[j]), 1 );
 *
 * NOTE: The physical centers of the input and output will be the
 * same. Because of this, the Origin of the output may not be the same

--- a/Base/Filtering/itktubeShrinkWithBlendingImageFilter.hxx
+++ b/Base/Filtering/itktubeShrinkWithBlendingImageFilter.hxx
@@ -233,7 +233,7 @@ ShrinkWithBlendingImageFilter< TInputImage, TOutputImage >
           }
         if( count > 0 )
           {
-          averageValue = vcl_sqrt( averageValue / count );
+          averageValue = std::sqrt( averageValue / count );
           }
         }
       else
@@ -267,8 +267,8 @@ ShrinkWithBlendingImageFilter< TInputImage, TOutputImage >
         for( unsigned int i = 0; i < ImageDimension; ++i )
           {
           double dist = (valueIndex[i] - inputIndex[i] ) / factorSize[i];
-          weight += (1.0 / (factorSize[i] * vcl_sqrt( 2 * vnl_math::pi )))
-            * vcl_exp( -0.5 * dist * dist );
+          weight += (1.0 / (factorSize[i] * std::sqrt( 2 * vnl_math::pi )))
+            * std::exp( -0.5 * dist * dist );
           }
         if( m_UseLog )
           {
@@ -286,7 +286,7 @@ ShrinkWithBlendingImageFilter< TInputImage, TOutputImage >
         {
         if( m_UseLog )
           {
-          outIt.Set( vcl_sqrt( averageValue / weightSum ) );
+          outIt.Set( std::sqrt( averageValue / weightSum ) );
           }
         else
           {

--- a/Base/Filtering/itktubeTubeEnhancingDiffusion2DImageFilter.hxx
+++ b/Base/Filtering/itktubeTubeEnhancingDiffusion2DImageFilter.hxx
@@ -407,9 +407,9 @@ TubeEnhancingDiffusion2DImageFilter<TPixel,TDimension>
 
   const Precision   Rb2 = (l1 * l1) / (l2 * l2); // btwn 0 and 1
   const Precision   S2 =  (l1 * l1) + (l2 *l2);
-  //const Precision   T = vcl_exp(-(2*smoothC*smoothC)/(vnl_math_abs(l1)*l2*l2));
+  //const Precision   T = std::exp(-(2*smoothC*smoothC)/(vnl_math_abs(l1)*l2*l2));
 
-  vesselness = vcl_exp( -Rb2/vb2 ) * (1.0 - vcl_exp( -S2/vc2 ) );
+  vesselness = std::exp( -Rb2/vb2 ) * (1.0 - std::exp( -S2/vc2 ) );
 
   return vesselness;
 }
@@ -457,9 +457,9 @@ TubeEnhancingDiffusion2DImageFilter<TPixel, TDimension>
     // adjusting eigenvalues
     // static_cast required to prevent error with gcc 4.1.2
     evn[0]   = 1.0 + (m_Epsilon - 1.0) *
-      vcl_pow(V,static_cast<Precision>(1.0/m_Sensitivity));
+      std::pow(V,static_cast<Precision>(1.0/m_Sensitivity));
     evn[1]   = 1.0 + (m_Epsilon - 1.0) *
-      vcl_pow(V,static_cast<Precision>(1.0/m_Sensitivity));
+      std::pow(V,static_cast<Precision>(1.0/m_Sensitivity));
 
     vnl_matrix<Precision> LAM(2,2);
     LAM.fill(0);

--- a/Base/Filtering/tubeImageFilters.hxx
+++ b/Base/Filtering/tubeImageFilters.hxx
@@ -1192,7 +1192,7 @@ ImageFilters<VDimension>
 ::EnhanceVessels( typename ImageType::Pointer imIn,
   double scaleMin, double scaleMax, double numScales )
 {
-  double logScaleStep = (vcl_log(scaleMax) - vcl_log(scaleMin))
+  double logScaleStep = (std::log(scaleMax) - std::log(scaleMin))
     / (numScales-1);
 
   typedef itk::tube::NJetImageFunction< ImageType > ImageFunctionType;
@@ -1233,7 +1233,7 @@ ImageFilters<VDimension>
     }
   for( unsigned int i=1; i<numScales; i++ )
     {
-    scale = vcl_exp(vcl_log(scaleMin) + i * logScaleStep);
+    scale = std::exp(std::log(scaleMin) + i * logScaleStep);
     std::cout << "   Processing scale " << scale << std::endl;
     it1.GoToBegin();
     it2.GoToBegin();

--- a/Base/Numerics/Testing/tubeBrentOptimizer1DTest.cxx
+++ b/Base/Numerics/Testing/tubeBrentOptimizer1DTest.cxx
@@ -37,7 +37,7 @@ public:
     }
   const double & Value( const double & x )
     {
-    cVal = vcl_sin(x);
+    cVal = std::sin(x);
     return cVal;
     }
 
@@ -55,7 +55,7 @@ public:
     }
   const double & Value( const double & x )
     {
-    cDeriv = vcl_cos(x);
+    cDeriv = std::cos(x);
     return cDeriv;
     }
 

--- a/Base/Numerics/Testing/tubeBrentOptimizerNDTest.cxx
+++ b/Base/Numerics/Testing/tubeBrentOptimizerNDTest.cxx
@@ -33,7 +33,7 @@ public:
     }
   const double & Value( const vnl_vector<double> & x )
     {
-    cVal = vcl_sin(x(0)) + vcl_sin(x(1));
+    cVal = std::sin(x(0)) + std::sin(x(1));
     return cVal;
     }
 
@@ -52,8 +52,8 @@ public:
     }
   const vnl_vector<double> & Value( const vnl_vector<double> & x )
     {
-    cDx[0] = vcl_cos(x(0));
-    cDx[1] = vcl_cos(x(1));
+    cDx[0] = std::cos(x(0));
+    cDx[1] = std::cos(x(1));
     std::cout << "deriv = " << cDx[0] << ", " << cDx[1] << std::endl;
     return cDx;
     }

--- a/Base/Numerics/Testing/tubeGoldenMeanOptimizer1DTest.cxx
+++ b/Base/Numerics/Testing/tubeGoldenMeanOptimizer1DTest.cxx
@@ -38,7 +38,7 @@ public:
 
   const double & Value( const double & x )
     {
-    cVal = vcl_sin(x);
+    cVal = std::sin(x);
     return cVal;
     }
 
@@ -57,7 +57,7 @@ public:
 
   const double & Value( const double & x )
     {
-    cVal = vcl_cos( x/100 );
+    cVal = std::cos( x/100 );
     std::cout << x << " : " << cVal << std::endl;
     return cVal;
     }

--- a/Base/Numerics/Testing/tubeParabolicFitOptimizer1DTest.cxx
+++ b/Base/Numerics/Testing/tubeParabolicFitOptimizer1DTest.cxx
@@ -37,7 +37,7 @@ public:
     }
   const double & Value( const double & x )
     {
-    cVal = vcl_sin(x);
+    cVal = std::sin(x);
     return cVal;
     }
 
@@ -55,7 +55,7 @@ public:
     }
   const double & Value( const double & x )
     {
-    cDeriv = vcl_cos(x);
+    cDeriv = std::cos(x);
     return cDeriv;
     }
 

--- a/Base/Numerics/Testing/tubeSplineApproximation1DTest.cxx
+++ b/Base/Numerics/Testing/tubeSplineApproximation1DTest.cxx
@@ -40,7 +40,7 @@ public:
     }
   const double & Value( const int & x )
     {
-    cVal = vcl_sin((double)x);
+    cVal = std::sin((double)x);
     return cVal;
     }
 
@@ -58,7 +58,7 @@ public:
     }
   const double & Value( const double & x )
     {
-    cVal = vcl_sin((double)x);
+    cVal = std::sin((double)x);
     return cVal;
     }
 
@@ -76,7 +76,7 @@ public:
     }
   const double & Value( const double & x )
     {
-    cDeriv = vcl_cos((double)x);
+    cDeriv = std::cos((double)x);
     return cDeriv;
     }
 

--- a/Base/Numerics/Testing/tubeSplineNDTest.cxx
+++ b/Base/Numerics/Testing/tubeSplineNDTest.cxx
@@ -41,8 +41,8 @@ public:
     }
   const double & Value( const vnl_vector<int> & x )
     {
-    cVal = vcl_sin((double)x[0]/2);
-    cVal += vcl_cos((double)x[1]/2);
+    cVal = std::sin((double)x[0]/2);
+    cVal += std::cos((double)x[1]/2);
     return cVal;
     }
 
@@ -60,8 +60,8 @@ public:
     }
   const double & Value( const vnl_vector<double> & x )
     {
-    cVal = vcl_sin((double)x[0]/2);
-    cVal += vcl_cos((double)x[1]/2);
+    cVal = std::sin((double)x[0]/2);
+    cVal += std::cos((double)x[1]/2);
     return cVal;
     }
 
@@ -81,8 +81,8 @@ public:
     }
   const vnl_vector<double> & Value( const vnl_vector<double> & x )
     {
-    cDeriv[0] = vcl_cos((double)x[0]/2);
-    cDeriv[1] = -vcl_sin((double)x[1]/2);
+    cDeriv[0] = std::cos((double)x[0]/2);
+    cDeriv[1] = -std::sin((double)x[1]/2);
     return cDeriv;
     }
 

--- a/Base/Numerics/Testing/tubeTubeMathTest.cxx
+++ b/Base/Numerics/Testing/tubeTubeMathTest.cxx
@@ -49,7 +49,7 @@ double tubeLength( itk::TubeSpatialObject<3> * tube )
       dist += ( pointItr->GetPosition()[d] - lastX[d] ) *
         ( pointItr->GetPosition()[d] - lastX[d] );
       }
-    length += vcl_sqrt( dist );
+    length += std::sqrt( dist );
     ++pointItr;
     }
 

--- a/Base/Numerics/Testing/tubeUserFunctionTest.cxx
+++ b/Base/Numerics/Testing/tubeUserFunctionTest.cxx
@@ -61,7 +61,7 @@ public:
   const vnl_vector<double> & Value( const vnl_vector<double> & x )
     {
     std::cout << "func:x = " << x[0] << ", " << x[1] << std::endl;
-    cVal[0] = vcl_sin(x[0]) + vcl_cos(x[1]/2);
+    cVal[0] = std::sin(x[0]) + std::cos(x[1]/2);
     std::cout << "  val = " << cVal << std::endl;
     return cVal;
     }

--- a/Base/Numerics/itktubeBlurImageFunction.hxx
+++ b/Base/Numerics/itktubeBlurImageFunction.hxx
@@ -205,7 +205,7 @@ BlurImageFunction<TInputImage>
           {
           double dist = index[0] * m_Spacing[0];
           dist = dist * dist + distY;
-          double w = vcl_exp( gfact*( dist ) );
+          double w = std::exp( gfact*( dist ) );
           m_KernelWeights.push_back( w );
           m_KernelX.push_back( index );
           m_KernelTotal += w;
@@ -223,7 +223,7 @@ BlurImageFunction<TInputImage>
         {
         double dist = index[0] * m_Spacing[0];
         dist = dist * dist + distY;
-        double w = vcl_exp( gfact*( dist ) );
+        double w = std::exp( gfact*( dist ) );
         m_KernelWeights.push_back( w );
         m_KernelX.push_back( index );
         m_KernelTotal += w;
@@ -460,7 +460,7 @@ BlurImageFunction<TInputImage>
             double dist = distX * distX + distY;
             if( dist <= kernrad )
               {
-              w = vcl_exp( gfact*dist );
+              w = std::exp( gfact*dist );
               wTotal += w;
               res += this->m_Image->GetPixel( kernelX ) * w;
               }
@@ -482,7 +482,7 @@ BlurImageFunction<TInputImage>
           double dist = distX * distX + distY;
           if( dist <= kernrad )
             {
-            w = vcl_exp( gfact*dist );
+            w = std::exp( gfact*dist );
             wTotal += w;
             res += this->m_Image->GetPixel( kernelX ) * w;
             }
@@ -522,7 +522,7 @@ BlurImageFunction<TInputImage>
             double dist = distX * distX + distY;
             if( dist <= kernrad )
               {
-              w = vcl_exp( gfact*( dist ) );
+              w = std::exp( gfact*( dist ) );
               wTotal += w;
               res += this->m_Image->GetPixel( kernelX ) * w;
               }
@@ -542,7 +542,7 @@ BlurImageFunction<TInputImage>
           double dist = distX * distX + distY;
           if( dist <= kernrad )
             {
-            w = vcl_exp( gfact*( dist ) );
+            w = std::exp( gfact*( dist ) );
             wTotal += w;
             res += this->m_Image->GetPixel( kernelX ) * w;
             }

--- a/Base/Numerics/itktubeFeatureVectorGenerator.hxx
+++ b/Base/Numerics/itktubeFeatureVectorGenerator.hxx
@@ -354,7 +354,7 @@ UpdateWhitenStatistics( void )
     {
     for( unsigned int i = 0; i < numFeatures; i++ )
       {
-      imStdDev[i] = vcl_sqrt( imStdDev[i] / ( imCount - 1 ) );
+      imStdDev[i] = std::sqrt( imStdDev[i] / ( imCount - 1 ) );
       }
     }
   else

--- a/Base/Numerics/itktubeImageRegionMomentsCalculator.hxx
+++ b/Base/Numerics/itktubeImageRegionMomentsCalculator.hxx
@@ -229,8 +229,8 @@ Compute( void )
   // Add a final reflection if needed for a proper rotation,
   // by multiplying the last row by the determinant
   vnl_real_eigensystem eigenrot( m_Pa.GetVnlMatrix() );
-  vnl_diag_matrix< vcl_complex<double> > eigenval = eigenrot.D;
-  vcl_complex<double> det( 1.0, 0.0 );
+  vnl_diag_matrix< std::complex<double> > eigenval = eigenrot.D;
+  std::complex<double> det( 1.0, 0.0 );
 
   for( unsigned int i=0; i<ImageDimension; i++ )
     {
@@ -239,7 +239,7 @@ Compute( void )
 
   for( unsigned int i=0; i<ImageDimension; i++ )
     {
-    m_Pa[ ImageDimension-1 ][i] *= vcl_real( det );
+    m_Pa[ ImageDimension-1 ][i] *= std::real( det );
     }
 
   /* Remember that the moments are valid */

--- a/Base/Numerics/itktubeJointHistogramImageFunction.hxx
+++ b/Base/Numerics/itktubeJointHistogramImageFunction.hxx
@@ -236,7 +236,7 @@ JointHistogramImageFunction<TInputImage,TCoordRep>
     while( !meanItr.IsAtEnd() )
       {
       meanItr.Set( sumItr.Get() / m_NumberOfSamples );
-      stdItr.Set( vcl_sqrt( vnl_math_abs(
+      stdItr.Set( std::sqrt( vnl_math_abs(
         sumOfSquaresItr.Get() / m_NumberOfSamples -
         meanItr.Get() * meanItr.Get() ) ) );
       ++sumItr;

--- a/Base/Numerics/itktubeNJetFeatureVectorGenerator.hxx
+++ b/Base/Numerics/itktubeNJetFeatureVectorGenerator.hxx
@@ -109,7 +109,7 @@ NJetFeatureVectorGenerator< TImage >
         featureVector[featureCount++] = v[d];
         val += v[d] * v[d];
         }
-      featureVector[featureCount++] = vcl_sqrt( val );
+      featureVector[featureCount++] = std::sqrt( val );
       }
 
     for( unsigned int s = 0; s < m_SecondScales.size(); s++ )
@@ -121,7 +121,7 @@ NJetFeatureVectorGenerator< TImage >
         featureVector[featureCount++] = m[d][d];
         val += m[d][d]*m[d][d];
         }
-      featureVector[featureCount++] = vcl_sqrt( val );
+      featureVector[featureCount++] = std::sqrt( val );
       }
 
     for( unsigned int s = 0; s < m_RidgeScales.size(); s++ )
@@ -209,7 +209,7 @@ NJetFeatureVectorGenerator< TImage >
           }
         if( featureCount == fNum )
           {
-          return ( vcl_sqrt( val ) - fNumMean ) / fNumStdDev;
+          return ( std::sqrt( val ) - fNumMean ) / fNumStdDev;
           }
         featureCount++;
         }
@@ -235,7 +235,7 @@ NJetFeatureVectorGenerator< TImage >
           }
         if( featureCount == fNum )
           {
-          return ( vcl_sqrt( val ) - fNumMean ) / fNumStdDev;
+          return ( std::sqrt( val ) - fNumMean ) / fNumStdDev;
           }
         featureCount++;
         }

--- a/Base/Numerics/itktubeNJetImageFunction.hxx
+++ b/Base/Numerics/itktubeNJetImageFunction.hxx
@@ -547,7 +547,7 @@ EvaluateAtContinuousIndex( const ContinuousIndexType & cIndex,
           {
           pixelValue = m_InputImage->GetPixel( xShift );
           }
-        expValue = vcl_exp( physGaussFactor * physDist );
+        expValue = std::exp( physGaussFactor * physDist );
 
         v += pixelValue * expValue;
         vTotal += vnl_math_abs( expValue );
@@ -929,7 +929,7 @@ DerivativeAtContinuousIndex( const ContinuousIndexType & cIndex,
           {
           pixelValue = m_InputImage->GetPixel( xShift );
           }
-        expValue = vcl_exp( physGaussFactor * physDist );
+        expValue = std::exp( physGaussFactor * physDist );
 
         v += pixelValue * expValue;
         vTotal += vnl_math_abs( expValue );
@@ -977,7 +977,7 @@ DerivativeAtContinuousIndex( const ContinuousIndexType & cIndex,
     }
   if( dMag != 0 )
     {
-    dMag = vcl_sqrt( dMag );
+    dMag = std::sqrt( dMag );
     }
 
   double val = 0;
@@ -1124,7 +1124,7 @@ DerivativeAtContinuousIndex( const ContinuousIndexType & cIndex,
   double dMag = ( d[0]*d[0] + d[1]*d[1] );
   if( dMag != 0 )
     {
-    dMag = vcl_sqrt( dMag );
+    dMag = std::sqrt( dMag );
     }
 
   return dMag;
@@ -1289,7 +1289,7 @@ HessianAtContinuousIndex( const ContinuousIndexType & cIndex,
     mag += h[i][i] * h[i][i];
     }
   // Should return the determinant
-  return vcl_sqrt( mag );
+  return std::sqrt( mag );
 }
 
 
@@ -1404,7 +1404,7 @@ HessianAtContinuousIndex( const ContinuousIndexType & cIndex,
   m_MostRecentHessian.Fill( 0 );
   m_MostRecentHessian[0][0] = m[0][0];
   m_MostRecentHessian[1][1] = m[1][1];
-  return vcl_sqrt( m[0][0]*m[0][0] + m[1][1]*m[1][1] );
+  return std::sqrt( m[0][0]*m[0][0] + m[1][1]*m[1][1] );
 }
 
 template< class TInputImage >
@@ -1577,7 +1577,7 @@ JetAtContinuousIndex( const ContinuousIndexType & cIndex, VectorType & d,
           pixelValue = m_InputImage->GetPixel( xShift );
           }
 
-        expValue = vcl_exp( physGaussFactor * physDist );
+        expValue = std::exp( physGaussFactor * physDist );
         v += pixelValue * expValue;
         vTotal += vnl_math_abs( expValue );
 

--- a/Base/Numerics/itktubeRidgeFFTFeatureVectorGenerator.hxx
+++ b/Base/Numerics/itktubeRidgeFFTFeatureVectorGenerator.hxx
@@ -103,7 +103,7 @@ RidgeFFTFeatureVectorGenerator< TImage >
 
     if( count > 1 )
       {
-      featureStdDev[i] = vcl_sqrt( featureStdDev[i] / ( count - 1 ) );
+      featureStdDev[i] = std::sqrt( featureStdDev[i] / ( count - 1 ) );
       }
     else
       {

--- a/Base/Numerics/tubeMatrixMath.hxx
+++ b/Base/Numerics/tubeMatrixMath.hxx
@@ -113,7 +113,7 @@ ComputeEuclideanDistanceVector(vnl_vector<T> x, const vnl_vector<T> y)
     {
     s += (x(i)-y(i))*(x(i)-y(i));
     }
-  return vcl_sqrt(s);
+  return std::sqrt(s);
 }
 
 /**
@@ -127,7 +127,7 @@ ComputeEuclideanDistance( TPoint x, TPoint y )
     {
     s += (x[i]-y[i])*(x[i]-y[i]);
     }
-  return vcl_sqrt(s);
+  return std::sqrt(s);
 }
 
 template< class T >
@@ -210,11 +210,11 @@ ComputeRidgeness( const vnl_matrix<T> & H,
     if( ImageDimension > 2 )
       {
       // Multiplied by 50 assuming the image is from 0 to 1;
-      curvature = ridge * vcl_sqrt( avgv ) * 50;
+      curvature = ridge * std::sqrt( avgv ) * 50;
       }
     else
       {
-      curvature = ridge * vcl_sqrt( avgv ) / 4;
+      curvature = ridge * std::sqrt( avgv ) / 4;
       }
     }
 

--- a/Base/Numerics/tubeOptimizerND.cxx
+++ b/Base/Numerics/tubeOptimizerND.cxx
@@ -169,7 +169,7 @@ OptimizerND
   m_X0.set_size( m_Dimension );
   m_X0.fill( 0.0 );
   m_X0Dir.set_size( m_Dimension );
-  m_X0Dir.fill( 1.0/vcl_sqrt((float)m_Dimension) );
+  m_X0Dir.fill( 1.0/std::sqrt((float)m_Dimension) );
   m_X0Temp.set_size( m_Dimension );
   m_X0Temp.fill( 0.0 );
 

--- a/Base/Numerics/tubeSpline1D.cxx
+++ b/Base/Numerics/tubeSpline1D.cxx
@@ -342,7 +342,7 @@ Spline1D
 
   double xpp = ValueD2(x);
 
-  return xpp/vcl_pow(1.0+xp*xp, 1.5);
+  return xpp/std::pow(1.0+xp*xp, 1.5);
 }
 
 

--- a/Base/Numerics/tubeSplineND.cxx
+++ b/Base/Numerics/tubeSplineND.cxx
@@ -517,7 +517,7 @@ SplineND
 
   for( int i=( int )m_Dimension-1; i>=0; i-- )
     {
-    unsigned int k = ( unsigned int )vcl_pow( ( float )4, ( int )i );
+    unsigned int k = ( unsigned int )std::pow( ( float )4, ( int )i );
     itDataWSColumn.GoToBegin();
     itDataWSDest.GoToBegin();
     for( unsigned int j=0; j<k; j++ )
@@ -569,7 +569,7 @@ SplineND
     {
     itDataWSColumn.GoToBegin();
     itDataWSDest.GoToBegin();
-    unsigned int k = ( unsigned int )vcl_pow( ( float )4, ( int )i );
+    unsigned int k = ( unsigned int )std::pow( ( float )4, ( int )i );
     switch( dx( ( int )m_Dimension-i-1 ) )
       {
       default:
@@ -766,7 +766,7 @@ SplineND
 
   for( int i=( int )m_Dimension-1; i>=0; i-- )
     {
-    unsigned int k = ( unsigned int )vcl_pow( ( float )4, ( int )i );
+    unsigned int k = ( unsigned int )std::pow( ( float )4, ( int )i );
 
     itk::ImageRegionIterator<ImageType> itImageWSX( itWSX->Value(),
       itWSX->Value()->GetLargestPossibleRegion() );

--- a/Base/Numerics/tubeTubeMath.hxx
+++ b/Base/Numerics/tubeTubeMath.hxx
@@ -184,7 +184,7 @@ ComputeVectorTangentsAndNormals( std::vector< TTubePoint > & tubeV )
       l = l + t[i]*t[i];
       }
 
-    l = vcl_sqrt(l);
+    l = std::sqrt(l);
     if(l < 0.0001)
       {
       std::cerr << "tubeTubeMath::ComputeVectorTangentsAndNormals() : ";

--- a/Base/Registration/Testing/itktubeAnisotropicDiffusiveRegistrationGenerateTestingImages.cxx
+++ b/Base/Registration/Testing/itktubeAnisotropicDiffusiveRegistrationGenerateTestingImages.cxx
@@ -149,7 +149,7 @@ bool PointInTube( TIndex index, double * tubeLeftPoint, double radius)
     distance += vnl_math_sqr(index[i] - centerPoint[i]);
     }
 
-  return vcl_sqrt(distance) <= radius;
+  return std::sqrt(distance) <= radius;
 }
 
 // Template function to fill in an image with two tubes

--- a/Base/Registration/itkAnisotropicSimilarity3DTransform.txx
+++ b/Base/Registration/itkAnisotropicSimilarity3DTransform.txx
@@ -155,7 +155,7 @@ AnisotropicSimilarity3DTransform<TScalarType>
   axis[2] = parameters[2];
   if( norm > 0 )
     {
-    norm = vcl_sqrt(norm);
+    norm = std::sqrt(norm);
     }
 
   double epsilon = 1e-10;
@@ -193,7 +193,7 @@ AnisotropicSimilarity3DTransform<TScalarType>
 //
 // Parameters are ordered as:
 //
-// p[0:2] = right part of the versor (axis times vcl_sin(t/2))
+// p[0:2] = right part of the versor (axis times std::sin(t/2))
 // p[3:5} = translation components
 // p[6:8} = scaling factor (isotropic)
 //

--- a/Base/Registration/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.txx
+++ b/Base/Registration/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.txx
@@ -561,9 +561,9 @@ AnisotropicSimilarityLandmarkBasedTransformInitializer<
 
         itkDebugMacro( << "Dot Product of landmarks: " << s_dot
           << " Cross Product: " << s_cross );
-        if( vcl_fabs( s_dot ) > 0.00005 )
+        if( std::fabs( s_dot ) > 0.00005 )
           {
-          rotationAngle = vcl_atan2( s_cross, s_dot );
+          rotationAngle = std::atan2( s_cross, s_dot );
           }
         else
           {

--- a/Base/Registration/itkImageRegionMomentsCalculator.txx
+++ b/Base/Registration/itkImageRegionMomentsCalculator.txx
@@ -211,8 +211,8 @@ ImageRegionMomentsCalculator<TImage>::Compute()
   // Add a final reflection if needed for a proper rotation,
   // by multiplying the last row by the determinant
   vnl_real_eigensystem                  eigenrot( m_Pa.GetVnlMatrix() );
-  vnl_diag_matrix<vcl_complex<double> > eigenval = eigenrot.D;
-  vcl_complex<double>                   det( 1.0, 0.0 );
+  vnl_diag_matrix<std::complex<double> > eigenval = eigenrot.D;
+  std::complex<double>                   det( 1.0, 0.0 );
   for( unsigned int i = 0; i < ImageDimension; i++ )
     {
     det *= eigenval( i, i );

--- a/Base/Registration/itktubeAnisotropicDiffusiveRegistrationFilter.hxx
+++ b/Base/Registration/itktubeAnisotropicDiffusiveRegistrationFilter.hxx
@@ -465,9 +465,9 @@ AnisotropicDiffusiveRegistrationFilter
       distance = 0.0;
       for( unsigned int i = 0; i < ImageDimension; i++ )
         {
-        distance += vcl_pow( imageCoord[i] - borderCoord[i], 2 );
+        distance += std::pow( imageCoord[i] - borderCoord[i], 2 );
         }
-      distance = vcl_sqrt( distance );
+      distance = std::sqrt( distance );
       // The weight image will temporarily store distances
       weightIt.Set( distance );
       }
@@ -565,7 +565,7 @@ AnisotropicDiffusiveRegistrationFilter
   < TFixedImage, TMovingImage, TDeformationField >
 ::ComputeWeightFromDistanceExponential( const WeightType distance ) const
 {
-  return vcl_exp( -1.0 * m_Lambda * distance );
+  return std::exp( -1.0 * m_Lambda * distance );
 }
 
 /**
@@ -582,7 +582,7 @@ AnisotropicDiffusiveRegistrationFilter
 ::ComputeWeightFromDistanceDirac( const WeightType distance ) const
 {
   return 1.0 - ( 1.0 / ( 1.0 + m_Lambda * m_Gamma
-                         * vcl_exp( -1.0 * m_Lambda * distance * distance ) ) );
+                         * std::exp( -1.0 * m_Lambda * distance * distance ) ) );
 }
 
 /**

--- a/Base/Registration/itktubeAnisotropicDiffusiveSparseRegistrationFilter.hxx
+++ b/Base/Registration/itktubeAnisotropicDiffusiveSparseRegistrationFilter.hxx
@@ -721,9 +721,9 @@ AnisotropicDiffusiveSparseRegistrationFilter
       surfaceDistance = 0.0;
       for( unsigned int i = 0; i < ImageDimension; i++ )
         {
-        surfaceDistance += vcl_pow( imageCoord[i] - borderCoord[i], 2 );
+        surfaceDistance += std::pow( imageCoord[i] - borderCoord[i], 2 );
         }
-      surfaceDistance = vcl_sqrt( surfaceDistance );
+      surfaceDistance = std::sqrt( surfaceDistance );
       }
     if( tubePointLocator )
       {
@@ -825,11 +825,11 @@ AnisotropicDiffusiveSparseRegistrationFilter
   double projection2 = 0.0;
   for( unsigned int i = 0; i < ImageDimension; i++ )
     {
-    projection1 += vcl_pow(relativePoint[i] * tangentVector1[i], 2);
-    projection2 += vcl_pow(relativePoint[i] * tangentVector2[i], 2);
+    projection1 += std::pow(relativePoint[i] * tangentVector1[i], 2);
+    projection2 += std::pow(relativePoint[i] * tangentVector2[i], 2);
     }
-  projection1 = vcl_sqrt( projection1 );
-  projection2 = vcl_sqrt( projection2 );
+  projection1 = std::sqrt( projection1 );
+  projection2 = std::sqrt( projection2 );
 
   double pointOnPlane[ImageDimension];
   for( unsigned int i = 0; i < ImageDimension; i++ )
@@ -841,9 +841,9 @@ AnisotropicDiffusiveSparseRegistrationFilter
   double distance = 0.0;
   for( unsigned int i = 0; i < ImageDimension; i++ )
     {
-    distance += vcl_pow( pointOnPlane[i], 2 );
+    distance += std::pow( pointOnPlane[i], 2 );
     }
-  distance = vcl_sqrt( distance );
+  distance = std::sqrt( distance );
   return distance;
 }
 
@@ -951,7 +951,7 @@ AnisotropicDiffusiveSparseRegistrationFilter
   < TFixedImage, TMovingImage, TDeformationField >
 ::ComputeWeightFromDistanceExponential( const WeightComponentType distance ) const
 {
-  return vcl_exp( -1.0 * m_Lambda * distance );
+  return std::exp( -1.0 * m_Lambda * distance );
 }
 
 /**
@@ -968,7 +968,7 @@ AnisotropicDiffusiveSparseRegistrationFilter
 ::ComputeWeightFromDistanceDirac( const WeightComponentType distance ) const
 {
   return 1.0 - ( 1.0 / ( 1.0 + m_Lambda * m_Gamma
-                         * vcl_exp( -1.0 * m_Lambda * distance * distance ) ) );
+                         * std::exp( -1.0 * m_Lambda * distance * distance ) ) );
 }
 
 /**

--- a/Base/Registration/itktubeDiffusiveRegistrationFilter.hxx
+++ b/Base/Registration/itktubeDiffusiveRegistrationFilter.hxx
@@ -1176,11 +1176,11 @@ DiffusiveRegistrationFilter
         localUpdateMetricsIntermediate.SumOfSquaredRegularizationUpdateMagnitude
             += squaredRegularizationUpdateMagnitude;
         localUpdateMetricsIntermediate.SumOfTotalUpdateMagnitude
-            += vcl_sqrt( squaredTotalUpdateMagnitude );
+            += std::sqrt( squaredTotalUpdateMagnitude );
         localUpdateMetricsIntermediate.SumOfIntensityDistanceUpdateMagnitude
-            += vcl_sqrt( squaredIntensityDistanceUpdateMagnitude );
+            += std::sqrt( squaredIntensityDistanceUpdateMagnitude );
         localUpdateMetricsIntermediate.SumOfRegularizationUpdateMagnitude
-            += vcl_sqrt( squaredRegularizationUpdateMagnitude );
+            += std::sqrt( squaredRegularizationUpdateMagnitude );
         }
 
       // Go to the next neighborhood
@@ -1548,13 +1548,13 @@ DiffusiveRegistrationFilter
     }
   else
     {
-    m_UpdateMetrics.RMSTotalUpdateMagnitude = vcl_sqrt(
+    m_UpdateMetrics.RMSTotalUpdateMagnitude = std::sqrt(
           m_UpdateMetrics.IntermediateStruct.SumOfSquaredTotalUpdateMagnitude
           / numPixels );
-    m_UpdateMetrics.RMSIntensityDistanceUpdateMagnitude = vcl_sqrt(
+    m_UpdateMetrics.RMSIntensityDistanceUpdateMagnitude = std::sqrt(
           m_UpdateMetrics.IntermediateStruct.SumOfSquaredIntensityDistanceUpdateMagnitude
           / numPixels );
-    m_UpdateMetrics.RMSRegularizationUpdateMagnitude = vcl_sqrt(
+    m_UpdateMetrics.RMSRegularizationUpdateMagnitude = std::sqrt(
           m_UpdateMetrics.IntermediateStruct.SumOfSquaredRegularizationUpdateMagnitude
           / numPixels );
     m_UpdateMetrics.MeanTotalUpdateMagnitude

--- a/Base/Registration/itktubeImageToTubeRigidMetric.hxx
+++ b/Base/Registration/itktubeImageToTubeRigidMetric.hxx
@@ -322,7 +322,7 @@ ImageToTubeRigidMetric< TFixedImage, TMovingSpatialObject, TTubeSpatialObject >
       const ScalarType distanceSquared = distance * distance;
       //! \todo cache this value, so it can be used in the next loop
       kernelSum += ( -1.0 + ( distanceSquared / scaleSquared ) )
-        * vcl_exp( -0.5 * distanceSquared / scaleSquared );
+        * std::exp( -0.5 * distanceSquared / scaleSquared );
       ++numberOfKernelPoints;
       }
     }
@@ -339,7 +339,7 @@ ImageToTubeRigidMetric< TFixedImage, TMovingSpatialObject, TTubeSpatialObject >
     const ScalarType distanceSquared = distance * distance;
     const ScalarType kernelValue =
       ( -1.0 + ( distanceSquared / scaleSquared ) )
-      * vcl_exp( -0.5 * distanceSquared / scaleSquared ) - error;
+      * std::exp( -0.5 * distanceSquared / scaleSquared ) - error;
 
     typename FixedImageType::PointType point;
     for( unsigned int ii = 0; ii < ImageDimension; ++ii )
@@ -607,7 +607,7 @@ ImageToTubeRigidMetric< TFixedImage, TMovingSpatialObject, TTubeSpatialObject >
     {
     const ScalarType distanceSquared = distance * distance;
     const ScalarType kernelValue =
-      2.0 * distance * vcl_exp( -0.5 * distanceSquared / scaleSquared );
+      2.0 * distance * std::exp( -0.5 * distanceSquared / scaleSquared );
 
     kernelSum += vnl_math_abs( kernelValue );
 

--- a/Base/Registration/itktubeMeanSquareRegistrationFunction.hxx
+++ b/Base/Registration/itktubeMeanSquareRegistrationFunction.hxx
@@ -151,7 +151,7 @@ MeanSquareRegistrationFunction<TFixedImage,TMovingImage,TDeformationField>
   if(normalizemetric)
     {
     denominator = speedValue*speedValue *fixedGradientSquaredMagnitude;
-    denominator = vcl_sqrt(denominator);
+    denominator = std::sqrt(denominator);
     }
   if(denominator == 0)
     {

--- a/Base/Registration/itktubeTubeAngleOfIncidenceWeightFunction.h
+++ b/Base/Registration/itktubeTubeAngleOfIncidenceWeightFunction.h
@@ -107,10 +107,10 @@ public:
     tangent.Normalize();
     const double dotProduct = beam * tangent;
     double cos_term =
-      vnl_math_abs( vcl_sqrt( 1.0 - dotProduct * dotProduct ) );
+      vnl_math_abs( std::sqrt( 1.0 - dotProduct * dotProduct ) );
     if( m_AngleDependence != 1.0 )
       {
-      cos_term = vcl_pow( cos_term, m_AngleDependence );
+      cos_term = std::pow( cos_term, m_AngleDependence );
       }
     return static_cast< WeightType >( 1.0 -
       m_FractionalImportance * ( 1.0 - cos_term ) );

--- a/Base/Registration/itktubeTubeExponentialResolutionWeightFunction.h
+++ b/Base/Registration/itktubeTubeExponentialResolutionWeightFunction.h
@@ -73,7 +73,7 @@ public:
     {
     const WeightType radius = tubePoint.GetRadius();
     return static_cast< WeightType >( 2.0 /
-      (1.0 + vcl_exp( -2.0 * radius ) ));
+      (1.0 + std::exp( -2.0 * radius ) ));
     }
 
 protected:

--- a/Base/Registration/itktubeTubeParametricExponentialResolutionWeightFunction.h
+++ b/Base/Registration/itktubeTubeParametricExponentialResolutionWeightFunction.h
@@ -69,7 +69,7 @@ public:
     {
     const OperatorValueType radius = tubePoint.GetRadius();
     return static_cast< OperatorValueType >( 1.0 /
-      (1.0 + this->m_Delta * (vcl_exp( -this->m_Alpha * radius ) - 1.0)));
+      (1.0 + this->m_Delta * (std::exp( -this->m_Alpha * radius ) - 1.0)));
     }
 
   void SetDelta( const OperatorValueType delta )

--- a/Base/Registration/itktubeTubeParametricExponentialWithBoundsResolutionWeightFunction.h
+++ b/Base/Registration/itktubeTubeParametricExponentialWithBoundsResolutionWeightFunction.h
@@ -73,7 +73,7 @@ public:
       return NumericTraits< OperatorValueType >::Zero;
       }
     return static_cast< OperatorValueType >( 1.0 /
-      (1.0 + this->GetDelta() * (vcl_exp( -this->GetAlpha() * radius ) - 1.0)));
+      (1.0 + this->GetDelta() * (std::exp( -this->GetAlpha() * radius ) - 1.0)));
     }
 
   void SetLowerBound( const OperatorValueType lowerBound )

--- a/Base/Segmentation/Testing/itktubeRidgeExtractorTest2.cxx
+++ b/Base/Segmentation/Testing/itktubeRidgeExtractorTest2.cxx
@@ -190,7 +190,7 @@ int itktubeRidgeExtractorTest2( int argc, char * argv[] )
       double tf = x0[i]-x1[i];
       diff += tf * tf;
       }
-    diff = vcl_sqrt( diff );
+    diff = std::sqrt( diff );
     if( diff > 2*pnt->GetRadius() && diff > 4 )
       {
       std::cout << "Local ridge test failed.  Local ridge too far."

--- a/Base/Segmentation/Testing/itktubeTubeExtractorTest.cxx
+++ b/Base/Segmentation/Testing/itktubeTubeExtractorTest.cxx
@@ -191,7 +191,7 @@ int itktubeTubeExtractorTest( int argc, char * argv[] )
       double tf = x0[i]-x1[i];
       diff += tf * tf;
       }
-    diff = vcl_sqrt( diff );
+    diff = std::sqrt( diff );
     if( diff > 2 )
       {
       std::cout << "Local tube test failed.  Local tube too far."

--- a/Base/Segmentation/itktubeRadiusExtractor2.hxx
+++ b/Base/Segmentation/itktubeRadiusExtractor2.hxx
@@ -358,8 +358,8 @@ RadiusExtractor2<TInputImage>
         ++pntIter;
         ++pntCount;
         }
-      m_KernelDistances[ count ] = vcl_sqrt( minNormalDist );
-      m_KernelTangentDistances[ count ] = vcl_sqrt( minTangentDist );
+      m_KernelDistances[ count ] = std::sqrt( minNormalDist );
+      m_KernelTangentDistances[ count ] = std::sqrt( minTangentDist );
       }
     else
       {
@@ -439,7 +439,7 @@ RadiusExtractor2<TInputImage>
   double distMin = 0;
   if( distMin2 > 0 )
     {
-    distMin = vcl_sqrt( distMin2 );
+    distMin = std::sqrt( distMin2 );
     }
   double areaMin = distMin * distMin * vnl_math::pi;
   double areaPos = areaR - areaMin;

--- a/Base/Segmentation/itktubeRidgeExtractor.hxx
+++ b/Base/Segmentation/itktubeRidgeExtractor.hxx
@@ -1066,7 +1066,7 @@ RidgeExtractor<TInputImage>
       continue;
       }
 
-    double diffX = vcl_sqrt(
+    double diffX = std::sqrt(
       ::tube::ComputeEuclideanDistanceVector( lX, pX ) );
     if( diffX > m_MaxXChange * GetScale() * stepFactor )
       {

--- a/Base/USTK/itkAcousticImpulseResponseImageFilter.hxx
+++ b/Base/USTK/itkAcousticImpulseResponseImageFilter.hxx
@@ -107,7 +107,7 @@ AcousticImpulseResponseImageFilter< TInputImage, TOutputImage, TOperatorValue >
          ++inputIt, ++angleOfIncidenceIt, ++gradientMagnitudeIt, ++outputIt )
       {
       outputIt.Set( static_cast< typename OutputImageType::PixelType >(
-        vcl_pow( static_cast< OperatorValueType >( angleOfIncidenceIt.Get() ),
+        std::pow( static_cast< OperatorValueType >( angleOfIncidenceIt.Get() ),
         static_cast< OperatorValueType >( this->m_AngleDependence *
         gradientMagnitudeIt.Get() / ( 2.0 * inputIt.Get() )))));
       }

--- a/Base/USTK/itktubeMarkDuplicateFramesInvalidImageFilter.hxx
+++ b/Base/USTK/itktubeMarkDuplicateFramesInvalidImageFilter.hxx
@@ -109,7 +109,7 @@ MarkDuplicateFramesInvalidImageFilterThreader< TAssociate >
       while( !currentSliceIt.IsAtEndOfLine() )
         {
         const float absDifference =
-          vcl_abs( static_cast< float >( currentSliceIt.Get() ) -
+          std::abs( static_cast< float >( currentSliceIt.Get() ) -
             static_cast< float >( nextSliceIt.Get() ) );
         if( absDifference <= tolerance )
           {


### PR DESCRIPTION
Adapted from Slicer [r24974](http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=24974) and InsightSoftwareConsortium/ITK@5f39086
originally contributed by Hans Johnson <hans-johnson@uiowa.edu>

In all supported compilers, the need for vcl_ specialized
functions has been removed.  there is no longer a need
to have these overrides, and code is easier to read
and easier to maintain without these specializations.

The vcl_* definitions can now be greatly simplified.
After removing specializations for early non-conformant
c++ compilers the end result was that only the
std:: version of the functions could ever be
used by the compiler.

```
ITK_SCRIPT=ITK/Utilities/Maintenance/VCL_ModernizeNaming.py
SRC_BASE_DIR=$(pwd)
for ext in ".h" ".cxx" ".cpp" ".hxx" ".hpp" ".txx"; do
  find ${SRC_BASE_DIR} -type f -name "*${ext}" -exec python ${ITK_SCRIPT} {} \;
done
```