### PR TITLE
COMP: Fixed compiler warnings.

### DIFF
--- a/Base/Filtering/itktubeTortuositySpatialObjectFilter.hxx
+++ b/Base/Filtering/itktubeTortuositySpatialObjectFilter.hxx
@@ -175,7 +175,7 @@ TortuositySpatialObjectFilter< TPointBasedSpatialObject >
     {
     std::cerr<<"CurvatureScalarMetric not computed"<<std::endl;
     }
-  else if( i < 0 || i >= this->m_CurvatureScalar.size() )
+  else if( i >= this->m_CurvatureScalar.size() )
     {
     std::cerr<<"GetCurvatureScalarMetric(int): Index "<<i<<" out of bounds"
       <<std::endl;
@@ -196,7 +196,7 @@ TortuositySpatialObjectFilter< TPointBasedSpatialObject >
     {
     std::cerr<<"InflectionPointMetric not computed"<<std::endl;
     }
-  else if( i < 0 || i >= this->m_InflectionPoints.Size() )
+  else if( i >= this->m_InflectionPoints.Size() )
     {
     std::cerr<<"GetInflectionPointValue(int): Index "<<i<<" out of bounds"
       <<std::endl;

--- a/SlicerModules/SpatialObjectsModule/MRML/vtkMRMLSpatialObjectsNode.h
+++ b/SlicerModules/SpatialObjectsModule/MRML/vtkMRMLSpatialObjectsNode.h
@@ -185,6 +185,9 @@ protected:
 
   std::set<int>                           m_SelectedTubeIds;
   std::map< int, std::vector<double> >    m_DefaultColorMap;
+
+private:
+  void Reset( vtkMRMLNode* defaultNode ) {};
 }; // End class vtkMRMLSpatialObjectsNode
 
 #endif // End !defined(__vtkMRMLSpatialObjectsNode_h)

--- a/SlicerModules/TortuosityModule/Widgets/qSlicerTortuosityModuleWidget.cxx
+++ b/SlicerModules/TortuosityModule/Widgets/qSlicerTortuosityModuleWidget.cxx
@@ -68,7 +68,6 @@ qSlicerTortuosityModuleWidgetPrivate
 //------------------------------------------------------------------------------
 int qSlicerTortuosityModuleWidgetPrivate::getFlagFromCheckBoxes()
 {
-  Q_Q( qSlicerTortuosityModuleWidget );
   int flag = this->BasicMetricsCheckBox->isChecked() ?
     vtkSlicerTortuosityLogic::BasicMetricsGroup : 0;
 


### PR DESCRIPTION
vtkMRMLSpatialObjectNode: ‘virtual void
vtkMRMLNode::Reset(vtkMRMLNode*)’ was hidden by ‘virtual void
vtkMRMLSpatialObjectsNode::Reset()’
itktubeTortuositySpatialObjectFilter: comparison of unsigned expression
< 0 is always false
qSlicerTortuosityModuleWidget: unused variable q