### PR TITLE
ENH: Added volume metrics in the basic metric group of tortuosity module

### DIFF
--- a/SlicerModules/TortuosityModule/Logic/vtkSlicerTortuosityLogic.h
+++ b/SlicerModules/TortuosityModule/Logic/vtkSlicerTortuosityLogic.h
@@ -59,9 +59,10 @@ public:
   void PrintSelf( ostream& os, vtkIndent indent );
 
   // typdefs
-  typedef vtkMRMLSpatialObjectsNode::TubeNetType                        TubeNetType;
-  typedef itk::VesselTubeSpatialObject< 3 >                             VesselTubeType;
-  typedef itk::tube::TortuositySpatialObjectFilter< VesselTubeType >    FilterType;
+  typedef vtkMRMLSpatialObjectsNode::TubeNetType                      TubeNetType;
+  typedef itk::VesselTubeSpatialObject< 3 >                           VesselTubeType;
+  typedef itk::tube::TortuositySpatialObjectFilter< VesselTubeType >  FilterType;
+  typedef VesselTubeType::TubePointType                               VesselTubePointType;
 
   // Different groups of metrics that can be run on a spatial object node.
   // See FilterType::MeasureType for more info on the metrics.


### PR DESCRIPTION
Volume of each tube is calculated as the sum of volumes of cylinders made by
consecutive points where radius is (r(t) + r(t+1))/2 and height is the
distance between two points.