### PR TITLE
ENH: tubeShrinkWithBlendingImage wrapped in Python

### DIFF
--- a/Applications/ShrinkImage/CMakeLists.txt
+++ b/Applications/ShrinkImage/CMakeLists.txt
@@ -43,7 +43,7 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/Base/CLI/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    TubeCLI TubeTKCommon TubeTKFiltering )
+    TubeCLI TubeTKCommon TubeTKFiltering TubeTKITK )
 
 if( BUILD_TESTING )
   add_subdirectory( Testing )

--- a/Applications/ShrinkImage/README.md
+++ b/Applications/ShrinkImage/README.md
@@ -3,3 +3,75 @@ TubeTK Shrink Image Application
 
 ---
 *This file is part of [TubeTK](http://www.tubetk.org). TubeTK is developed by [Kitware, Inc.](http://www.kitware.com) and licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).*
+
+#### Overview:
+
+Project an image into fewer slices. Integration uses the 'max' function.
+
+Author(s): Stephen R. Aylward (Kitware)
+
+Acknowledgements: This work is part of the TubeTK project at Kitware.
+
+#### Commandline Usage:
+
+   ShrinkImage  [--returnparameterfile <std::string>]
+                [--processinformationaddress <std::string>] [--xml]
+                [--echo] [-p <std::string>] [-m] [-l] [-g] [-o
+                <std::vector<int>>] [-n <std::vector<int>>] [-d
+                <std::vector<int>>] [--] [--version] [-h] <std::string>
+                <std::string>
+
+Where:
+
+   --returnparameterfile <std::string>
+     Filename in which to write simple return parameters (int, float,
+     int-vector, etc.) as opposed to bulk return parameters (image,
+     geometry, transform, measurement, table).
+
+   --processinformationaddress <std::string>
+     Address of a structure to store process information (progress, abort,
+     etc.). (default: 0)
+
+   --xml
+     Produce xml description of command line arguments (default: 0)
+
+   --echo
+     Echo the command line arguments (default: 0)
+
+   -p <std::string>,  --mipPointImage <std::string>
+     Save a vector image containing physical point of max pixel's original
+     location
+
+   -m,  --mean
+     Generate new voxel using mean (instead of max) (default: 0)
+
+   -l,  --log
+     Compute the values in the log domain (default: 0)
+
+   -g,  --gaussian
+     Generate new voxel using a centered Gaussian weight (instead of max)
+     (default: 0)
+
+   -o <std::vector<int>>,  --overlap <std::vector<int>>
+     Amount each sliding window region should overlap (in pixels)
+
+   -n <std::vector<int>>,  --newSize <std::vector<int>>
+     Target size of each dimension (size/newSize must be an integer)
+
+   -d <std::vector<int>>,  --divideBy <std::vector<int>>
+     Size of each dimension is divide by this much (must be integers)
+
+   --,  --ignore_rest
+     Ignores the rest of the labeled arguments following this flag.
+
+   --version
+     Displays version information and exits.
+
+   -h,  --help
+     Displays usage information and exits.
+
+   <std::string>
+     (required)  Input image.
+
+   <std::string>
+     (required)  Output image.

--- a/Applications/ShrinkImage/ShrinkImage.cxx
+++ b/Applications/ShrinkImage/ShrinkImage.cxx
@@ -119,6 +119,8 @@ int DoIt( int argc, char * argv[] )
 
   typename FilterType::ShrinkFactorsType shrinkFactors;
   shrinkFactors.Fill( 1 );
+  typename FilterType::InputSizeType newInputSize;
+  newInputSize.Fill( 1 );
 
   typename FilterType::InputIndexType overlapVoxels;
 
@@ -173,6 +175,7 @@ int DoIt( int argc, char * argv[] )
       {
       shrinkFactors[ i ] = divideBy[ i ];
       }
+      filter->SetShrinkFactors( shrinkFactors );
     }
 
   if( newSize.size() > 0 )
@@ -189,32 +192,12 @@ int DoIt( int argc, char * argv[] )
       std::cout << "match the dimensionality of the image." << std::endl;
       return EXIT_FAILURE;
       }
-    bool warnSize = false;
     for( unsigned int i = 0; i < VDimension; ++i )
       {
-      shrinkFactors[ i ] = static_cast< int >( inSize[ i ] / newSize[ i ] );
-      if( static_cast< int >( inSize[ i ] / shrinkFactors[ i ] )
-        != newSize[ i ] )
-        {
-        warnSize = true;
-        }
+      newInputSize[ i ] = newSize[ i ];
       }
-    if( warnSize )
-      {
-      std::cout << "Warning: Need for integer resampling factor causes ";
-      std::cout << "output size to not match target newSize given."
-        << std::endl;
-      for( unsigned int i = 0; i < VDimension; ++i )
-        {
-        std::cout << "   newSize [" << i << "] = " << newSize[ i ]
-          << std::endl;
-        std::cout << "   outSize [" << i << "] = " << static_cast< int >(
-          inSize[ i ] / shrinkFactors[ i ] ) << std::endl;
-        }
-      }
+    filter->SetNewSize(newInputSize);
     }
-
-  filter->SetShrinkFactors( shrinkFactors );
 
   tube::CLIFilterWatcher watcher( filter, "Shrink Filter",
     CLPProcessInformation, progress, 0.8, true );

--- a/Applications/ShrinkImage/ShrinkImage.cxx
+++ b/Applications/ShrinkImage/ShrinkImage.cxx
@@ -29,7 +29,7 @@ limitations under the License.
 #include <itkImageFileWriter.h>
 #include <itkImageFileReader.h>
 
-#include <itktubeShrinkWithBlendingImageFilter.h>
+#include <tubeShrinkWithBlendingImage.h>
 
 // Must include CLP before including tubeCLIHelperFunctions
 #include "ShrinkImageCLP.h"
@@ -68,7 +68,7 @@ int DoIt( int argc, char * argv[] )
   typedef itk::Image< PointPixelType, VDimension > PointImageType;
   typedef itk::ImageFileWriter< PointImageType >   PointImageWriterType;
 
-  typedef itk::tube::ShrinkWithBlendingImageFilter< InputImageType,
+  typedef tube::ShrinkWithBlendingImage< InputImageType,
     OutputImageType > FilterType;
 
   timeCollector.Start("Load data");

--- a/Base/Filtering/itktubeShrinkWithBlendingImageFilter.h
+++ b/Base/Filtering/itktubeShrinkWithBlendingImageFilter.h
@@ -52,6 +52,13 @@ limitations under the License.
 
 #include "itkShrinkImageFilter.h"
 
+// Forward declare itkTubeTK class to allow friendship
+namespace tube
+{
+template< typename tube_TInputImage, typename tube_TOutputImage >
+class ShrinkWithBlendingImage;
+}
+
 namespace itk {
 
 namespace tube {
@@ -179,6 +186,9 @@ private:
 
   ShrinkFactorsType m_ShrinkFactors;
 
+  /** friendship facilitating itkTukeTK integration */
+  template< typename tube_TInputImage, typename tube_TOutputImage >
+  friend class ::tube::ShrinkWithBlendingImage;
 };
 
 } // end namespace tube

--- a/Base/Filtering/itktubeShrinkWithBlendingImageFilter.h
+++ b/Base/Filtering/itktubeShrinkWithBlendingImageFilter.h
@@ -120,6 +120,7 @@ public:
   typedef typename TOutputImage::OffsetType     OutputOffsetType;
 
   typedef typename TOutputImage::RegionType     OutputImageRegionType;
+  typedef typename TInputImage::SizeType        InputSizeType;
 
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TInputImage::ImageDimension );
@@ -135,8 +136,10 @@ public:
 
   /** Set the shrink factors. Values are clamped to
    * a minimum value of 1. Default is 1 for all dimensions. */
-  itkSetMacro( ShrinkFactors, ShrinkFactorsType );
+  void SetShrinkFactors( ShrinkFactorsType factors);
   void SetShrinkFactor(unsigned int i, unsigned int factor);
+  void SetNewSize( InputSizeType newSize );
+  itkGetMacro(NewSize, InputSizeType);
 
   /** Get the shrink factors. */
   itkGetConstReferenceMacro(ShrinkFactors, ShrinkFactorsType);
@@ -156,6 +159,10 @@ public:
   itkSetMacro( UseLog, bool );
   itkGetMacro( UseLog, bool );
 
+  itkSetMacro( UseNewSize, bool );
+  itkGetMacro( UseNewSize, bool );
+  itkBooleanMacro(UseNewSize);
+
   itkGetObjectMacro( PointImage, PointImageType );
 
   void GenerateOutputInformation( void );
@@ -169,6 +176,7 @@ protected:
 
   void ThreadedGenerateData( const OutputImageRegionType &
     outputRegionForThread, ThreadIdType threadId );
+  void UpdateShrinkFactors();
 
 private:
   ShrinkWithBlendingImageFilter( const Self & ); //purposely not implemented
@@ -183,8 +191,10 @@ private:
   bool m_BlendWithMean;
   bool m_BlendWithMax;
   bool m_BlendWithGaussianWeighting;
+  bool m_UseNewSize;
 
-  ShrinkFactorsType m_ShrinkFactors;
+  ShrinkFactorsType                  m_ShrinkFactors;
+  InputSizeType                      m_NewSize;
 
   /** friendship facilitating itkTukeTK integration */
   template< typename tube_TInputImage, typename tube_TOutputImage >

--- a/Examples/ShrinkImage/ShrinkImage.py
+++ b/Examples/ShrinkImage/ShrinkImage.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# Copyright 2014 Kitware Inc. 28 Corporate Drive,
+# Clifton Park, NY, 12065, USA.
+#
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Shrink an image
+
+Command line arguments (See command line help: -h):
+---------------------------------------------------
+    Required:
+        --inputImage (string): input image.
+        --outputImage (string): output image.
+        --factor (integer): factor by which the image is shrunk
+"""
+
+
+import itk
+import argparse
+import sys
+
+def ShrinkImage(inputFileName,outputFileName,factor):
+  """Loads input image.
+     Shrinks image.
+     Writes output in given file name.
+  """
+  reader=itk.ImageFileReader.New(FileName=inputFileName)
+  filter=itk.TubeTKITK.ShrinkWithBlendingImage.New(reader)
+  filter.SetShrinkFactors([factor,factor,factor])
+  writer=itk.ImageFileWriter.New(filter,FileName=outputFileName)
+  writer.Update()
+
+
+def main(argv=None):
+    """Parsing command line arguments and reading input files."""
+    if argv is None:
+        argv = sys.argv
+    parser = argparse.ArgumentParser(
+            prog=argv[0],
+            description=__doc__
+    )
+    parser.add_argument('-i', "--inputFileName", type=str, required=True, help="Input image")
+    parser.add_argument('-o', "--outputFileName", type=str, required=True, help="Output image")
+    parser.add_argument('-f', "--factor", type=int, required=True, help="Shrink factor")
+    args = parser.parse_args(argv[1:])
+    ShrinkImage(args.inputFileName,args.outputFileName,args.factor)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ITKModules/TubeTKITK/include/tubeShrinkWithBlendingImage.h
+++ b/ITKModules/TubeTKITK/include/tubeShrinkWithBlendingImage.h
@@ -36,8 +36,8 @@ class ShrinkWithBlendingImage:
 public:
     /** Standard class typedefs. */
     typedef ShrinkWithBlendingImage                         Self;
-    typedef itk::SmartPointer< Self >                            Pointer;
-    typedef itk::SmartPointer< const Self >                      ConstPointer;
+    typedef itk::SmartPointer< Self >                       Pointer;
+    typedef itk::SmartPointer< const Self >                 ConstPointer;
 
     /** Method for creation through the object factory. */
     itkNewMacro( Self );
@@ -49,13 +49,8 @@ public:
     /** Typedef to images */
     typedef TOutputImage                          OutputImageType;
     typedef TInputImage                           InputImageType;
-//    typedef typename OutputImageType::Pointer     OutputImagePointer;
-//    typedef typename InputImageType::Pointer      InputImagePointer;
-//    typedef typename InputImageType::ConstPointer InputImageConstPointer;
-
-//    typedef typename TOutputImage::IndexType      OutputIndexType;
     typedef typename TInputImage::IndexType       InputIndexType;
-//    typedef typename TOutputImage::OffsetType     OutputOffsetType;
+    typedef typename TInputImage::SizeType        InputSizeType;
 
     itkStaticConstMacro( ImageDimension, unsigned int,
                          TInputImage::ImageDimension );
@@ -65,7 +60,7 @@ public:
 
     typedef itk::Vector< float, ImageDimension >       PointImagePixelType;
     typedef itk::Image< PointImagePixelType, OutputImageDimension >
-                                                  PointImageType;
+                                                       PointImageType;
 
     typedef itk::FixedArray< unsigned int, ImageDimension > ShrinkFactorsType;
 
@@ -73,6 +68,12 @@ public:
      * a minimum value of 1. Default is 1 for all dimensions. */
     void SetShrinkFactors(ShrinkFactorsType ShrinkFactors);
     void SetShrinkFactor(unsigned int i, unsigned int factor);
+
+    void SetNewSize(InputSizeType newSize);
+    InputSizeType GetNewSize();
+
+    void SetUseNewSize( bool useNewSize);
+    bool GetUseNewSize();
 
     /** Get the shrink factors. */
     ShrinkFactorsType GetShrinkFactors();
@@ -112,7 +113,8 @@ private:
   ShrinkWithBlendingImage(const Self &);
   void operator=(const Self &);
 
-  typedef itk::tube::ShrinkWithBlendingImageFilter< InputImageType, OutputImageType > ShrinkWithBlendingFilterType;
+  typedef itk::tube::ShrinkWithBlendingImageFilter< InputImageType,
+                            OutputImageType > ShrinkWithBlendingFilterType;
   typename ShrinkWithBlendingFilterType::Pointer m_ShrinkWithBlendingFilter;
 
 };

--- a/ITKModules/TubeTKITK/include/tubeShrinkWithBlendingImage.h
+++ b/ITKModules/TubeTKITK/include/tubeShrinkWithBlendingImage.h
@@ -1,0 +1,126 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+*=========================================================================*/
+#ifndef __tubeShrinkWithBlendingImage_h
+#define __tubeShrinkWithBlendingImage_h
+
+#include "itktubeShrinkWithBlendingImageFilter.h"
+#include "itkObject.h"
+
+
+namespace tube
+{
+/** \class ShrinkWithBlendingImage
+ *
+ *  \ingroup TubeTKITK
+ */
+
+template< typename TInputImage, typename TOutputImage >
+class ShrinkWithBlendingImage:
+  public itk::ProcessObject
+{
+public:
+    /** Standard class typedefs. */
+    typedef ShrinkWithBlendingImage                         Self;
+    typedef itk::SmartPointer< Self >                            Pointer;
+    typedef itk::SmartPointer< const Self >                      ConstPointer;
+
+    /** Method for creation through the object factory. */
+    itkNewMacro( Self );
+
+    /** Run-time type information (and related methods). */
+    itkTypeMacro( ShrinkWithBlendingImage, Object );
+
+
+    /** Typedef to images */
+    typedef TOutputImage                          OutputImageType;
+    typedef TInputImage                           InputImageType;
+//    typedef typename OutputImageType::Pointer     OutputImagePointer;
+//    typedef typename InputImageType::Pointer      InputImagePointer;
+//    typedef typename InputImageType::ConstPointer InputImageConstPointer;
+
+//    typedef typename TOutputImage::IndexType      OutputIndexType;
+    typedef typename TInputImage::IndexType       InputIndexType;
+//    typedef typename TOutputImage::OffsetType     OutputOffsetType;
+
+    itkStaticConstMacro( ImageDimension, unsigned int,
+                         TInputImage::ImageDimension );
+
+    itkStaticConstMacro( OutputImageDimension, unsigned int,
+                         TOutputImage::ImageDimension );
+
+    typedef itk::Vector< float, ImageDimension >       PointImagePixelType;
+    typedef itk::Image< PointImagePixelType, OutputImageDimension >
+                                                  PointImageType;
+
+    typedef itk::FixedArray< unsigned int, ImageDimension > ShrinkFactorsType;
+
+    /** Set the shrink factors. Values are clamped to
+     * a minimum value of 1. Default is 1 for all dimensions. */
+    void SetShrinkFactors(ShrinkFactorsType ShrinkFactors);
+    void SetShrinkFactor(unsigned int i, unsigned int factor);
+
+    /** Get the shrink factors. */
+    ShrinkFactorsType GetShrinkFactors();
+
+    void SetOverlap(InputIndexType overlap );
+    InputIndexType  GetOverlap();
+
+    void SetBlendWithMean( bool blendWithMean );
+    bool GetBlendWithMean();
+
+    void SetBlendWithMax( bool blendWithMax);
+    bool GetBlendWithMax();
+
+    void SetBlendWithGaussianWeighting( bool blendWithGaussianWeighting);
+    bool GetBlendWithGaussianWeighting();
+
+    void SetUseLog( bool useLog);
+    bool GetUseLog();
+
+    PointImageType* GetPointImage();
+
+    void GenerateOutputInformation( void );
+
+    void GenerateInputRequestedRegion( void );
+
+    void SetInput( const InputImageType *inputImage );
+    void Update(void);
+    typename OutputImageType::Pointer GetOutput(void);
+
+protected:
+  ShrinkWithBlendingImage( void );
+  ~ShrinkWithBlendingImage() {}
+  void PrintSelf(std::ostream & os, itk::Indent indent) const;
+
+private:
+  /** itkShrinkWithBlendingImageFilter parameters **/
+  ShrinkWithBlendingImage(const Self &);
+  void operator=(const Self &);
+
+  typedef itk::tube::ShrinkWithBlendingImageFilter< InputImageType, OutputImageType > ShrinkWithBlendingFilterType;
+  typename ShrinkWithBlendingFilterType::Pointer m_ShrinkWithBlendingFilter;
+
+};
+} // End namespace tube
+
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "tubeShrinkWithBlendingImage.hxx"
+#endif
+
+#endif // End !defined( __tubeShrinkWithBlendingImage_h )

--- a/ITKModules/TubeTKITK/include/tubeShrinkWithBlendingImage.hxx
+++ b/ITKModules/TubeTKITK/include/tubeShrinkWithBlendingImage.hxx
@@ -1,0 +1,279 @@
+/*=========================================================================
+
+Library:   TubeTK
+
+Copyright 2010 Kitware Inc. 28 Corporate Drive,
+Clifton Park, NY, 12065, USA.
+
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=========================================================================*/
+#ifndef __tubeShrinkWithBlendingImage_hxx
+#define __tubeShrinkWithBlendingImage_hxx
+
+#include "tubeShrinkWithBlendingImage.h"
+
+namespace tube {
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::ShrinkWithBlendingImage( void )
+{
+    m_ShrinkWithBlendingFilter = ShrinkWithBlendingFilterType::New();
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+void
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::PrintSelf( std::ostream & os, itk::Indent  indent ) const
+{
+    m_ShrinkWithBlendingFilter->PrintSelf( os, indent);
+}
+
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+void
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::SetShrinkFactors(ShrinkFactorsType shrinkFactors)
+{
+    m_ShrinkWithBlendingFilter->SetShrinkFactors(shrinkFactors);
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+void
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::SetShrinkFactor(unsigned int i, unsigned int factor)
+{
+    m_ShrinkWithBlendingFilter->SetShrinkFactor(i,factor);
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+typename ShrinkWithBlendingImage< TInputImage, TOutputImage >::ShrinkFactorsType
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::GetShrinkFactors(void)
+{
+    return m_ShrinkWithBlendingFilter->GetShrinkFactors();
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+void
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::SetOverlap(InputIndexType overlap )
+{
+    m_ShrinkWithBlendingFilter->SetOverlap(overlap);
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+typename ShrinkWithBlendingImage< TInputImage, TOutputImage >::InputIndexType
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::GetOverlap(void)
+{
+    return m_ShrinkWithBlendingFilter->GetOverlap();
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+void
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::SetBlendWithMean( bool blendWithMean )
+{
+    m_ShrinkWithBlendingFilter->SetBlendWithMean(blendWithMean);
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+bool
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::GetBlendWithMean(void)
+{
+    return m_ShrinkWithBlendingFilter->GetBlendWithMean();
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+void
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::SetBlendWithMax( bool blendWithMax)
+{
+    m_ShrinkWithBlendingFilter->SetBlendWithMax(blendWithMax);
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+bool
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::GetBlendWithMax(void)
+{
+    return m_ShrinkWithBlendingFilter->GetBlendWithMax();
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+void
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::SetBlendWithGaussianWeighting( bool blendWithGaussianWeighting)
+{
+    m_ShrinkWithBlendingFilter->SetBlendWithGaussianWeighting(blendWithGaussianWeighting);
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+bool
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::GetBlendWithGaussianWeighting(void)
+{
+    return m_ShrinkWithBlendingFilter->GetBlendWithGaussianWeighting();
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+void
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::SetUseLog( bool useLog)
+{
+    m_ShrinkWithBlendingFilter->SetUseLog(useLog);
+}
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+bool
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::GetUseLog(void)
+{
+    return m_ShrinkWithBlendingFilter->GetUseLog();
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+typename ShrinkWithBlendingImage<TInputImage, TOutputImage>::PointImageType *
+ShrinkWithBlendingImage<TInputImage, TOutputImage>
+::GetPointImage(void)
+{
+    return m_ShrinkWithBlendingFilter->GetPointImage();
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+void
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::GenerateOutputInformation( void )
+{
+    m_ShrinkWithBlendingFilter->GenerateOutputInformation();
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+void
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::GenerateInputRequestedRegion( void )
+{
+    m_ShrinkWithBlendingFilter->GenerateInputRequestedRegion();
+}
+
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+void
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::SetInput( const TInputImage *inputImage )
+{
+    m_ShrinkWithBlendingFilter->SetInput(inputImage);
+}
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+void
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::Update()
+{
+    m_ShrinkWithBlendingFilter->Update();
+}
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+typename TOutputImage::Pointer
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::GetOutput()
+{
+    return m_ShrinkWithBlendingFilter->GetOutput();
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+} // end namespace tube
+
+#endif

--- a/ITKModules/TubeTKITK/include/tubeShrinkWithBlendingImage.hxx
+++ b/ITKModules/TubeTKITK/include/tubeShrinkWithBlendingImage.hxx
@@ -34,7 +34,7 @@ template< class TInputImage, class TOutputImage >
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::ShrinkWithBlendingImage( void )
 {
-    m_ShrinkWithBlendingFilter = ShrinkWithBlendingFilterType::New();
+  m_ShrinkWithBlendingFilter = ShrinkWithBlendingFilterType::New();
 }
 
 /**
@@ -45,7 +45,7 @@ void
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::PrintSelf( std::ostream & os, itk::Indent  indent ) const
 {
-    m_ShrinkWithBlendingFilter->PrintSelf( os, indent);
+  m_ShrinkWithBlendingFilter->PrintSelf( os, indent);
 }
 
 
@@ -57,7 +57,7 @@ void
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::SetShrinkFactors(ShrinkFactorsType shrinkFactors)
 {
-    m_ShrinkWithBlendingFilter->SetShrinkFactors(shrinkFactors);
+  m_ShrinkWithBlendingFilter->SetShrinkFactors(shrinkFactors);
 }
 
 /**
@@ -68,7 +68,51 @@ void
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::SetShrinkFactor(unsigned int i, unsigned int factor)
 {
-    m_ShrinkWithBlendingFilter->SetShrinkFactor(i,factor);
+  m_ShrinkWithBlendingFilter->SetShrinkFactor(i,factor);
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+void
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::SetNewSize(InputSizeType newSize)
+{
+  m_ShrinkWithBlendingFilter->SetNewSize(newSize);
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+typename ShrinkWithBlendingImage< TInputImage, TOutputImage >::InputSizeType
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::GetNewSize(void)
+{
+  return m_ShrinkWithBlendingFilter->GetNewSize();
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+void
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::SetUseNewSize( bool useNewSize)
+{
+  m_ShrinkWithBlendingFilter->SetUseNewSize(useNewSize);
+}
+
+/**
+ *
+ */
+template< class TInputImage, class TOutputImage >
+bool
+ShrinkWithBlendingImage< TInputImage, TOutputImage >
+::GetUseNewSize()
+{
+  return m_ShrinkWithBlendingFilter->GetUseNewSize();
 }
 
 /**
@@ -79,7 +123,7 @@ typename ShrinkWithBlendingImage< TInputImage, TOutputImage >::ShrinkFactorsType
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::GetShrinkFactors(void)
 {
-    return m_ShrinkWithBlendingFilter->GetShrinkFactors();
+  return m_ShrinkWithBlendingFilter->GetShrinkFactors();
 }
 
 /**
@@ -90,7 +134,7 @@ void
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::SetOverlap(InputIndexType overlap )
 {
-    m_ShrinkWithBlendingFilter->SetOverlap(overlap);
+  m_ShrinkWithBlendingFilter->SetOverlap(overlap);
 }
 
 /**
@@ -101,7 +145,7 @@ typename ShrinkWithBlendingImage< TInputImage, TOutputImage >::InputIndexType
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::GetOverlap(void)
 {
-    return m_ShrinkWithBlendingFilter->GetOverlap();
+  return m_ShrinkWithBlendingFilter->GetOverlap();
 }
 
 /**
@@ -112,7 +156,7 @@ void
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::SetBlendWithMean( bool blendWithMean )
 {
-    m_ShrinkWithBlendingFilter->SetBlendWithMean(blendWithMean);
+  m_ShrinkWithBlendingFilter->SetBlendWithMean(blendWithMean);
 }
 
 /**
@@ -123,7 +167,7 @@ bool
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::GetBlendWithMean(void)
 {
-    return m_ShrinkWithBlendingFilter->GetBlendWithMean();
+  return m_ShrinkWithBlendingFilter->GetBlendWithMean();
 }
 
 /**
@@ -134,7 +178,7 @@ void
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::SetBlendWithMax( bool blendWithMax)
 {
-    m_ShrinkWithBlendingFilter->SetBlendWithMax(blendWithMax);
+  m_ShrinkWithBlendingFilter->SetBlendWithMax(blendWithMax);
 }
 
 /**
@@ -145,7 +189,7 @@ bool
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::GetBlendWithMax(void)
 {
-    return m_ShrinkWithBlendingFilter->GetBlendWithMax();
+  return m_ShrinkWithBlendingFilter->GetBlendWithMax();
 }
 
 /**
@@ -156,7 +200,7 @@ void
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::SetBlendWithGaussianWeighting( bool blendWithGaussianWeighting)
 {
-    m_ShrinkWithBlendingFilter->SetBlendWithGaussianWeighting(blendWithGaussianWeighting);
+  m_ShrinkWithBlendingFilter->SetBlendWithGaussianWeighting(blendWithGaussianWeighting);
 }
 
 /**
@@ -167,7 +211,7 @@ bool
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::GetBlendWithGaussianWeighting(void)
 {
-    return m_ShrinkWithBlendingFilter->GetBlendWithGaussianWeighting();
+  return m_ShrinkWithBlendingFilter->GetBlendWithGaussianWeighting();
 }
 
 /**
@@ -178,7 +222,7 @@ void
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::SetUseLog( bool useLog)
 {
-    m_ShrinkWithBlendingFilter->SetUseLog(useLog);
+  m_ShrinkWithBlendingFilter->SetUseLog(useLog);
 }
 /**
  *
@@ -188,7 +232,7 @@ bool
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::GetUseLog(void)
 {
-    return m_ShrinkWithBlendingFilter->GetUseLog();
+  return m_ShrinkWithBlendingFilter->GetUseLog();
 }
 
 /**
@@ -199,7 +243,7 @@ typename ShrinkWithBlendingImage<TInputImage, TOutputImage>::PointImageType *
 ShrinkWithBlendingImage<TInputImage, TOutputImage>
 ::GetPointImage(void)
 {
-    return m_ShrinkWithBlendingFilter->GetPointImage();
+  return m_ShrinkWithBlendingFilter->GetPointImage();
 }
 
 /**
@@ -210,7 +254,7 @@ void
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::GenerateOutputInformation( void )
 {
-    m_ShrinkWithBlendingFilter->GenerateOutputInformation();
+  m_ShrinkWithBlendingFilter->GenerateOutputInformation();
 }
 
 /**
@@ -221,9 +265,8 @@ void
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::GenerateInputRequestedRegion( void )
 {
-    m_ShrinkWithBlendingFilter->GenerateInputRequestedRegion();
+  m_ShrinkWithBlendingFilter->GenerateInputRequestedRegion();
 }
-
 
 /**
  *
@@ -233,8 +276,9 @@ void
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::SetInput( const TInputImage *inputImage )
 {
-    m_ShrinkWithBlendingFilter->SetInput(inputImage);
+  m_ShrinkWithBlendingFilter->SetInput(inputImage);
 }
+
 /**
  *
  */
@@ -243,8 +287,9 @@ void
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::Update()
 {
-    m_ShrinkWithBlendingFilter->Update();
+  m_ShrinkWithBlendingFilter->Update();
 }
+
 /**
  *
  */
@@ -253,26 +298,8 @@ typename TOutputImage::Pointer
 ShrinkWithBlendingImage< TInputImage, TOutputImage >
 ::GetOutput()
 {
-    return m_ShrinkWithBlendingFilter->GetOutput();
+  return m_ShrinkWithBlendingFilter->GetOutput();
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 } // end namespace tube
 

--- a/ITKModules/TubeTKITK/wrapping/tubeShrinkWithBlendingImage.wrap
+++ b/ITKModules/TubeTKITK/wrapping/tubeShrinkWithBlendingImage.wrap
@@ -1,0 +1,10 @@
+itk_wrap_include( tubeShrinkWithBlendingImage.h )
+itk_wrap_include( itkImage.h )
+
+itk_wrap_named_class("tube::ShrinkWithBlendingImage" tubeShrinkWithBlendingImage POINTER)
+ foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_SCALAR})
+      itk_wrap_template("I${ITKM_${t}}${d}I${ITKM_${t}}${d}"  "itk::Image<${ITKT_${t}}, ${d}>, itk::Image<${ITKT_${t}}, ${d}>")
+    endforeach()
+ endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
As part of this process, an ITK compliant API of itktubeShrinkWithBlendingImageFilter
has been created (tubeShrinkWithBlendingImage). The filter ShrinkWithBlendingImage is
available in the package itk.TubeTKITK when ITK is built with ITK_WRAP_PYTHON set to ON.