### PR TITLE
ENH: Check if numpy is available on the system

### DIFF
--- a/CMake/CheckPythonLibrary.cmake
+++ b/CMake/CheckPythonLibrary.cmake
@@ -1,0 +1,57 @@
+# - Find python libraries
+# returns:
+# - ${library}_ERROR - TRUE if more than one argument is given to the macro
+# - ${library}_FOUND - TRUE if the library could be found
+#=============================================================================
+# Copyright 2001-2009 Kitware, Inc.
+# Copyright 2012 Continuum Analytics, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+# nor the names of their contributors may be used to endorse or promote
+# products derived from this software without specific prior written
+# permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# # A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#=============================================================================
+
+macro(CheckPythonLibrary library)
+  set(${library}_ERROR TRUE)
+  set(${library}_FOUND FALSE)
+  #Sanity check: Make sure only one library name is given
+  if(${ARGC} EQUAL 1)
+    set(list_var "${ARGN}")
+    find_package(PythonInterp REQUIRED)
+
+    execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+      "exec(\"import sys\\ntry:\\n  import numpy\\nexcept:\\n  print 'hel'\\n  sys.exit(0)\\nprint 'hel1'\\nsys.exit(1)\")"
+      RESULT_VARIABLE ${library}_FOUND
+      OUTPUT_VARIABLE _PYTHON_VALUES
+      ERROR_VARIABLE _PYTHON_ERROR_VALUE
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    set(${library}_ERROR FALSE)
+  endif()
+endmacro()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,9 +363,14 @@ option( TubeTK_USE_PYTHON "Use Python to enable additional functionality."
 
 if( TubeTK_USE_PYTHON )
 
+  include(CheckPythonLibrary)
   # NumPy conversion support.
   option( TubeTK_USE_NUMPY "Use NumPy to enable additional functionality." ON )
   mark_as_advanced( CLEAR TubeTK_USE_NUMPY )
+  CheckPythonLibrary(numpy)
+  if( TubeTK_USE_NUMPY AND NOT numpy_FOUND )
+    message(FATAL_ERROR "numpy was not found. Set TubeTK_USE_NUMPY to OFF")
+  endif()
 
   # Test TubeTK examples via Python virtualenv.
   option( TubeTK_USE_IPYTHON_NOTEBOOKS "Use IPython notebooks in TubeTK." ON )


### PR DESCRIPTION
If one tries to build TubeTK with the option TubeTK_USE_NUMPY
and if numpy is not available on the system, TubeTK will not
compile correctly. To avoid receiving an error message at compilation
time, a test to verify that numpy is available at configuration
time.