### PR TITLE
ENH: Bump CircleCI Docker image Slicer version.

### DIFF
--- a/CMake/CircleCI/CircleCI_slicer_Docker/Dockerfile
+++ b/CMake/CircleCI/CircleCI_slicer_Docker/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /usr/src
 
-ENV Slicer_GIT_TAG 68786fd2574926c7e79915e092ccc8c03abb450c
+ENV Slicer_GIT_TAG 1865f51e5450f243f71314a9a568541afad76d0f
 RUN git clone https://github.com/Slicer/Slicer.git && \
   cd Slicer && \
   git checkout ${Slicer_GIT_TAG} && \


### PR DESCRIPTION
Includes an update to ITK.