### PR TITLE
COMP: Update ITK to address itk::NumericTraits::Zero build errors.

### DIFF
--- a/CMake/Superbuild/ExternalProjectsConfig.cmake
+++ b/CMake/Superbuild/ExternalProjectsConfig.cmake
@@ -87,7 +87,7 @@ set( CTK_HASH_OR_TAG caaf2c8cdee08e95bc823ab92865e1e9153dcc04 )
 
 # Insight Segmentation and Registration Toolkit
 set( ITK_URL ${github_protocol}://github.com/Slicer/ITK.git )
-set( ITK_HASH_OR_TAG 9fa8f6333a4d66f31f26527b2eb23e170a0e6e16 )
+set( ITK_HASH_OR_TAG 58a7203f9ec431f9fe71ac087d0bd7e02b495634 )
 
 # Slicer Execution Model
 set( SlicerExecutionModel_URL


### PR DESCRIPTION
This includes
InsightSoftwareConsortium/ITK@5aa604c9942612957dd0d6f2bf8f2fbca928885b
which should address dashboard build errors like:

   TubeTK-Debug/TubeTK-build/ITKModules/MinimalPathExtraction/test/MinimalPathTest.h:211:
   undefined reference to `itk::NumericTraits::Zero'