### PR TITLE
BUG: ComputeRidgeness checks for tangent direction

### DIFF
--- a/Base/Filtering/itktubeRidgeFFTFilter.hxx
+++ b/Base/Filtering/itktubeRidgeFFTFilter.hxx
@@ -168,7 +168,8 @@ RidgeFFTFilter< TInputImage >
           ++count;
           }
         }
-      ::tube::ComputeRidgeness( H, D, ridgeness, roundness, curvature,
+      vnl_vector<double> prevTangent;
+      ::tube::ComputeRidgeness( H, D, prevTangent, ridgeness, roundness, curvature,
         levelness, HEVect, HEVal );
       iterRidge.Set( ridgeness );
       iterRound.Set( roundness );

--- a/Base/Numerics/itktubeNJetImageFunction.hxx
+++ b/Base/Numerics/itktubeNJetImageFunction.hxx
@@ -1824,7 +1824,8 @@ RidgenessAtContinuousIndex( const ContinuousIndexType & cIndex,
   double levelness = 0;
   vnl_matrix<double> eVect( ImageDimension, ImageDimension );
   vnl_vector<double> eVal( ImageDimension );
-  ::tube::ComputeRidgeness<double>( h.GetVnlMatrix(), d.GetVnlVector(),
+  vnl_vector<double> prevTangent;
+  ::tube::ComputeRidgeness<double>( h.GetVnlMatrix(), d.GetVnlVector(), prevTangent,
     ridgeness, roundness, curvature, levelness,
     eVect, eVal );
 

--- a/Base/Numerics/tubeMatrixMath.h
+++ b/Base/Numerics/tubeMatrixMath.h
@@ -68,6 +68,7 @@ template< class T >
 void
 ComputeRidgeness( const vnl_matrix<T> & H,
   const vnl_vector<T> & D,
+  const vnl_vector<double> & prevTangent,
   double & ridgeness,
   double & roundness,
   double & curvature,

--- a/Base/Segmentation/itktubeRidgeExtractor.h
+++ b/Base/Segmentation/itktubeRidgeExtractor.h
@@ -292,7 +292,8 @@ public:
     double & intensity,
     double & roundness,
     double & curvature,
-    double & levelness );
+    double & levelness,
+    const vnl_vector<double> & prevTangent=vnl_vector<double>());
 
   /** Get current location
    *  This is location at which the Ridgness function was last called


### PR DESCRIPTION
Before computing ridgeness, roudness, curvature and levelness, the
ComputeRidgeness function now checks for the tangent and normals
direction and reorder them if needed.