### PR TITLE
BUG: FATAL instead of FATAL_ERROR in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,7 +258,7 @@ if( TubeTK_BUILD_USING_SLICER )
   # Find Slicer to set the [ITK|VTK|CTK|...]_DIR variables
   find_package( Slicer REQUIRED )
   if( NOT Slicer_USE_FILE )
-    message( FATAL "Slicer_USE_FILE not defined. Find Slicer silently failed." )
+    message( FATAL_ERROR "Slicer_USE_FILE not defined. Find Slicer silently failed." )
   endif( NOT Slicer_USE_FILE )
   include( ${Slicer_USE_FILE} )
 


### PR DESCRIPTION
When calling message(FATAL "..."), the configuration process is not
interrupted and one can still generate the project. The key word
that needs to be used in CMake to stop the configuration is
'FATAL_ERROR'.