### PR TITLE
ENH: Verifies that ITK and TubeTIK wrapping option match

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,6 +601,12 @@ include( ${SlicerExecutionModel_USE_FILE} )
 
 find_package( ITK REQUIRED )
 include( ${ITK_USE_FILE} )
+# Sanity check
+if( ITK_WRAPPING AND NOT TubeTK_USE_PYTHON)
+  message(FATAL_ERROR "ITK_WRAPPING is set to ON and TubeTK_USE_PYTHON is set to OFF. Please rebuild ITK with all ITK_WRAPPING_* set to OFF or set TubeTK_USE_PYTHON to ON ")
+endif()
+
+
 if( TubeTK_USE_VTK )
   find_package( VTK REQUIRED )
   include( ${VTK_USE_FILE} )


### PR DESCRIPTION
If TubeTK_USE_PYTHON is set to OFF but ITK_WRAPPING is ON,
wrapping will still be performed. To avoid running into this
expected behavior, an error message is printed at configuration
time. Setting TubeTK_USE_PYTHON to ON while having ITK_WRAPPING
set to OFF is not an issue: Python code of TubeTK will be used,
but TubeTK ITK C++ classes will not be wrapped in Python.
It is worth noting that there is no ITK_WRAPPING option accessible
when configuring ITK. The value of ITK_WRAPPING is set depending
on the value of ITK_WRAPPING_PYTHON, ITK_WRAPPING_JAVA, and so on.