### PR TITLE
BUG: tubeComputeBinaryImageSimilarityMetrics works only for integers

### DIFF
--- a/ITKModules/TubeTKITK/wrapping/tubeComputeBinaryImageSimilarityMetrics.wrap
+++ b/ITKModules/TubeTKITK/wrapping/tubeComputeBinaryImageSimilarityMetrics.wrap
@@ -3,7 +3,7 @@ itk_wrap_include( itkImage.h )
 
 itk_wrap_named_class("tube::ComputeBinaryImageSimilarityMetrics" tubeComputeBinaryImageSimilarityMetrics POINTER)
  foreach(d ${ITK_WRAP_IMAGE_DIMS})
-    foreach(t ${WRAP_ITK_SCALAR})
+    foreach(t ${WRAP_ITK_INT}))
       itk_wrap_template("I${ITKM_${t}}${d}"  "itk::Image<${ITKT_${t}}, ${d}>")
     endforeach()
  endforeach()


### PR DESCRIPTION
tubeComputeBinaryImageSimilarityMetrics should only be wrapped for
integers types, not for float and double.