### PR TITLE
ENH: CACHE variables should not always be removed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,10 +250,14 @@ if( TubeTK_BUILD_USING_SLICER )
     TubeTK_USE_CTK )
 
   #set(TubeTK_BUILD_WITHIN_SLICER ${TubeTK_BUILD_USING_SLICER})
-  unset( QT_QMAKE_EXECUTABLE CACHE)
-  unset( PYTHON_EXECUTABLE CACHE)
-  unset( PYTHON_INCLUDE_DIR CACHE)
-  unset( PYTHON_LIBRARY CACHE)
+  # Do not unset these variables if project is built as
+  # a Slicer extension within Slicer.
+  if( NOT TubeTK_BUILD_WITHIN_SLICER)
+    unset( QT_QMAKE_EXECUTABLE CACHE)
+    unset( PYTHON_EXECUTABLE CACHE)
+    unset( PYTHON_INCLUDE_DIR CACHE)
+    unset( PYTHON_LIBRARY CACHE)
+  endif()
 
   # Find Slicer to set the [ITK|VTK|CTK|...]_DIR variables
   find_package( Slicer REQUIRED )


### PR DESCRIPTION
When building TubeTK as a Slicer extension withing Slicer (e.g. as
part of VesselView), CACHE variables that are passed to TubeTK
should not be unset as they are not reset by SlicerConfig.cmake.
Indeed, in this case, SlicerConfig.cmake does not contain values
for these CACHE variables. The SlicerConfig.cmake file used in
this case is not the one contained in the build directory of Slicer,
but the one contained in the subdirectory containing the extensions.