### PR TITLE
ENH: PARSE_ARGS_INT_ONLY added to ParseArgsAndCallDoIt()

### DIFF
--- a/Applications/ComputeBinaryImageSimilarityMetrics/ComputeBinaryImageSimilarityMetrics.cxx
+++ b/Applications/ComputeBinaryImageSimilarityMetrics/ComputeBinaryImageSimilarityMetrics.cxx
@@ -29,6 +29,8 @@ limitations under the License.
 template< class TPixel, unsigned int VDimension >
 int DoIt( int argc, char * argv[] );
 
+#define PARSE_ARGS_INT_ONLY 1
+
 // Must follow include of "...CLP.h" and forward declaration of int DoIt( ... ).
 #include "tubeCLIHelperFunctions.h"
 
@@ -37,7 +39,7 @@ int DoIt( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  typedef short                                               PixelType;
+  typedef TPixel                                              PixelType;
   typedef itk::Image< PixelType, VDimension >                 ImageType;
   typedef itk::ImageFileReader< ImageType >                   ReaderType;
 

--- a/Base/CLI/tubeCLIHelperFunctions.h
+++ b/Base/CLI/tubeCLIHelperFunctions.h
@@ -86,10 +86,12 @@ int ParseArgsAndCallDoIt( const std::string & inputImage, int argc,
           return DoIt< unsigned short, 2 >( argc, argv );
         case ImageIOType::SHORT:
           return DoIt< short, 2 >( argc, argv );
+#ifndef PARSE_ARGS_INT_ONLY
         case ImageIOType::FLOAT:
           return DoIt< float, 2 >( argc, argv );
         case ImageIOType::DOUBLE:
           return DoIt< double, 2 >( argc, argv );
+#endif
         case ImageIOType::INT:
           return DoIt< int, 2 >( argc, argv );
         case ImageIOType::UINT:
@@ -114,10 +116,12 @@ int ParseArgsAndCallDoIt( const std::string & inputImage, int argc,
           return DoIt < unsigned short, 3 >( argc, argv );
         case ImageIOType::SHORT:
           return DoIt< short, 3 >( argc, argv );
+#ifndef PARSE_ARGS_INT_ONLY
         case ImageIOType::FLOAT:
           return DoIt < float, 3 >( argc, argv );
         case ImageIOType::DOUBLE:
           return DoIt < double, 3 >( argc, argv );
+#endif
         case ImageIOType::INT:
           return DoIt< int, 3 >( argc, argv );
         case ImageIOType::UINT:


### PR DESCRIPTION
If an application supports only integer pixel types, it is
now possible to use ParseArgsAndCallDoIt() and the templated
function DoIt() to handle all integer types
(such as 'int', 'short',...) without supporting float types.