### PR TITLE
BUG: MinimalPathExtraction is a dependency for TubeTKITK

### DIFF
--- a/Base/Segmentation/itktubeSegmentTubesUsingMinimalPathFilter.h
+++ b/Base/Segmentation/itktubeSegmentTubesUsingMinimalPathFilter.h
@@ -30,11 +30,6 @@
 #include "itkGradientDescentOptimizer.h"
 #include "itkNumericTraits.h"
 
-// MinimalPathExtraction Imports
-#include "itkSpeedFunctionToPathFilter.h"
-#include "itkIterateNeighborhoodOptimizer.h"
-#include "itkSingleImageCostFunction.h"
-
 //TubeTK imports
 #include "itktubeRadiusExtractor2.h"
 #include "itktubeSpatialObjectToSpatialObjectFilter.h"

--- a/Base/Segmentation/itktubeSegmentTubesUsingMinimalPathFilter.hxx
+++ b/Base/Segmentation/itktubeSegmentTubesUsingMinimalPathFilter.hxx
@@ -20,6 +20,11 @@
 
 #include "itktubeSegmentTubesUsingMinimalPathFilter.h"
 
+// MinimalPathExtraction Imports
+#include "itkSpeedFunctionToPathFilter.h"
+#include "itkIterateNeighborhoodOptimizer.h"
+#include "itkSingleImageCostFunction.h"
+
 namespace itk
 {
 namespace tube


### PR DESCRIPTION
Include files from MinimalPathExtraction need to be found
by CastXML when wrapping TubeTKITK. Therefore
MinimalPathExtraction needs to be added as a dependency of
TubeTKITK. This will allow to generate the .inc file
that contains all the path to the include files used by
TubeTKITK.