### PR TITLE
BUG: Couldn't find MinimalPathExtraction include files

### DIFF
--- a/CMake/Superbuild/ExternalProjectsConfig.cmake
+++ b/CMake/Superbuild/ExternalProjectsConfig.cmake
@@ -71,8 +71,8 @@ set( MinimalPathExtraction_HASH_OR_TAG
   aed93f4ac350ee8d0c3411e885fff86095443b7a )
 
 set( TubeTK_ITK_MODULES
-  TubeTKITK
   MinimalPathExtraction
+  TubeTKITK
   )
 
 ###########################################################

--- a/ITKModules/TubeTKITK/itk-module.cmake
+++ b/ITKModules/TubeTKITK/itk-module.cmake
@@ -4,6 +4,7 @@ set(DOCUMENTATION
 itk_module( TubeTKITK
   DEPENDS
     ITKCommon
+    MinimalPathExtraction
   EXCLUDE_FROM_DEFAULT
   DESCRIPTION
     "${DOCUMENTATION}"


### PR DESCRIPTION
Include files from MinimalPathExtraction need to be found
by CastXML when wrapping TubeTKITK.