### PR TITLE
ENH: Changed the base class for SegmentTubesUsingMinimumPath filter.

### DIFF
--- a/Applications/SegmentTubeUsingMinimalPath/SegmentTubeUsingMinimalPath.cxx
+++ b/Applications/SegmentTubeUsingMinimalPath/SegmentTubeUsingMinimalPath.cxx
@@ -97,7 +97,6 @@ int DoIt( int argc, char * argv[] )
       {
       reader->Update();
       filter->SetRadiusImage( reader->GetOutput() );
-      filter->SetExtractRadius( true );
       filter->SetStartRadius( StartRadius );
       filter->SetMaxRadius( MaxRadius );
       filter->SetStepSizeForRadiusEstimation( StepRadius );
@@ -121,8 +120,7 @@ int DoIt( int argc, char * argv[] )
       {
       tubeFileReader->SetFileName( TargetTubeFileName.c_str() );
       tubeFileReader->Update();
-      filter->SetInput( tubeFileReader->GetGroup() );
-      filter->SetExtractEndPointFromTargetTube( true );
+      filter->SetTargetTubeGroup( tubeFileReader->GetGroup() );
       if( ConnectionOption == "Connect_To_Target_Tube_Surface" )
         {
         filter->SetConnectToTargetTubeSurface( true );
@@ -135,11 +133,6 @@ int DoIt( int argc, char * argv[] )
       timeCollector.Report();
       return EXIT_FAILURE;
       }
-    }
-  else
-    {
-    typename TubeGroupType::Pointer inputTubeGroup =TubeGroupType::New();
-    filter->SetInput( inputTubeGroup );
     }
 
   timeCollector.Stop( "Load data" );
@@ -165,19 +158,19 @@ int DoIt( int argc, char * argv[] )
     }
 
   if( IntermediatePoints.size() >= 1 )
-  {
-  std::vector< PointType > intermediatePathPoints;
-  for( unsigned int k = 0; k < IntermediatePoints.size(); k++ )
     {
-    PointType pathPoint;
-    for( unsigned int i = 0; i < DimensionT; i++ )
+    std::vector< PointType > intermediatePathPoints;
+    for( unsigned int k = 0; k < IntermediatePoints.size(); k++ )
       {
-       pathPoint[i]=IntermediatePoints[k][i];
+      PointType pathPoint;
+      for( unsigned int i = 0; i < DimensionT; i++ )
+        {
+         pathPoint[i]=IntermediatePoints[k][i];
+        }
+      intermediatePathPoints.push_back( pathPoint );
       }
-    intermediatePathPoints.push_back( pathPoint );
+    filter->SetIntermediatePoints( intermediatePathPoints );
     }
-  filter->SetIntermediatePoints( intermediatePathPoints );
-  }
 
   if( EndPoint.size() == 1 )
     {

--- a/Base/Segmentation/itktubeSegmentTubesUsingMinimalPathFilter.h
+++ b/Base/Segmentation/itktubeSegmentTubesUsingMinimalPathFilter.h
@@ -29,10 +29,9 @@
 #include "itkPolyLineParametricPath.h"
 #include "itkGradientDescentOptimizer.h"
 #include "itkNumericTraits.h"
-
+#include "itkObject.h"
 //TubeTK imports
 #include "itktubeRadiusExtractor2.h"
-#include "itktubeSpatialObjectToSpatialObjectFilter.h"
 
 namespace itk
 {
@@ -46,35 +45,28 @@ namespace tube
  *
  */
 
-template< class TInputSpatialObject, class TInputImage >
-class SegmentTubesUsingMinimalPathFilter:
-  public SpatialObjectToSpatialObjectFilter
-  < TInputSpatialObject, TInputSpatialObject >
+template< unsigned int Dimension, class TInputPixel >
+class SegmentTubesUsingMinimalPathFilter: public Object
 {
 public:
   /** Standard class typedefs. */
   typedef SegmentTubesUsingMinimalPathFilter              Self;
-  typedef SpatialObjectToSpatialObjectFilter
-    < TInputSpatialObject, TInputSpatialObject >          Superclass;
+  typedef Object                                          Superclass;
   typedef SmartPointer< Self >                            Pointer;
   typedef SmartPointer< const Self >                      ConstPointer;
-
-  typedef TInputSpatialObject                      InputSpatialObjectType;
-  typedef TInputImage                              InputImageType;
+  typedef itk::Image< TInputPixel, Dimension >            InputImageType;
+  typedef itk::GroupSpatialObject< Dimension >            InputSpatialObjectType;
+  typedef typename InputSpatialObjectType::Pointer        TubeGroupPointer;
+  typedef itk::Point< double, Dimension >                 PointType;
+  typedef itk::VesselTubeSpatialObjectPoint< Dimension >  TubePointType;
+  typedef itk::VesselTubeSpatialObject< Dimension >       TubeType;
 
   /** Method for creation through the object factory. */
-  itkNewMacro(Self);
+  itkNewMacro( Self );
 
   /** Run-time type information (and related methods). */
   itkTypeMacro
-    (SegmentTubesUsingMinimalPathFilter, SpatialObjectToSpatialObjectFilter);
-
-  itkStaticConstMacro( ImageDimension, unsigned int,
-                       TInputImage::ImageDimension );
-
-  typedef itk::Point< double, ImageDimension >                PointType;
-  typedef itk::VesselTubeSpatialObjectPoint< ImageDimension > TubePointType;
-  typedef itk::VesselTubeSpatialObject< ImageDimension >      TubeType;
+    ( SegmentTubesUsingMinimalPathFilter, Object );
 
   itkSetMacro( SpeedImage, typename InputImageType::Pointer );
   itkGetMacro( SpeedImage, typename InputImageType::Pointer );
@@ -84,12 +76,8 @@ public:
   itkGetMacro( StartPoint, PointType );
   itkSetMacro( EndPoint, PointType );
   itkGetMacro( EndPoint, PointType );
-  itkSetMacro( ExtractEndPointFromTargetTube, bool );
-  itkGetMacro( ExtractEndPointFromTargetTube, bool );
   itkSetMacro( ConnectToTargetTubeSurface, bool );
   itkGetMacro( ConnectToTargetTubeSurface, bool );
-  itkSetMacro( ExtractRadius, bool );
-  itkGetMacro( ExtractRadius, bool );
   itkSetMacro( OptimizationMethod, std::string );
   itkGetMacro( OptimizationMethod, std::string );
   itkSetMacro( OptimizerTerminationValue, double );
@@ -108,31 +96,32 @@ public:
   itkGetMacro( StepSizeForRadiusEstimation, double );
   itkGetMacro( CostAssociatedWithExtractedTube, double );
   itkSetMacro( CostAssociatedWithExtractedTube, double );
+  /** Sets the input tubes */
+  itkSetMacro( TargetTubeGroup, TubeGroupPointer );
+  itkGetMacro( TargetTubeGroup, TubeGroupPointer );
+  itkGetMacro( Output, TubeGroupPointer );
 
   void SetIntermediatePoints( std::vector< PointType > );
+  void Update( void );
 protected:
   SegmentTubesUsingMinimalPathFilter( void );
   ~SegmentTubesUsingMinimalPathFilter() {}
 
-  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
-
-  virtual void GenerateData( void );
+  void PrintSelf(std::ostream & os, Indent indent) const;
   bool IsPointTooNear( const InputSpatialObjectType * sourceTubeGroup,
               PointType outsidePoint,
               PointType &nearestPoint );
 private:
-
-  SegmentTubesUsingMinimalPathFilter(const Self &);
-  void operator=(const Self &);
+  SegmentTubesUsingMinimalPathFilter( const Self & );
+  void operator=( const Self & );
 
   typename InputImageType::Pointer  m_SpeedImage;
   typename InputImageType::Pointer  m_RadiusImage;
   PointType                         m_StartPoint;
   PointType                         m_EndPoint;
   std::vector< PointType >          m_IntermediatePoints;
-  bool                              m_ExtractEndPointFromTargetTube;
+  TubeGroupPointer                  m_TargetTubeGroup;
   bool                              m_ConnectToTargetTubeSurface;
-  bool                              m_ExtractRadius;
   std::string                       m_OptimizationMethod;
   double                            m_OptimizerTerminationValue;
   int                               m_OptimizerNumberOfIterations;
@@ -142,6 +131,7 @@ private:
   double                            m_MaxRadius;
   double                            m_StepSizeForRadiusEstimation;
   double                            m_CostAssociatedWithExtractedTube;
+  TubeGroupPointer                  m_Output;
 
 }; //End class SegmentTubesUsingMinimalPathFilter
 } // End namespace tube

--- a/ITKModules/TubeTKITK/include/tubeSegmentTubesUsingMinimalPath.h
+++ b/ITKModules/TubeTKITK/include/tubeSegmentTubesUsingMinimalPath.h
@@ -45,13 +45,14 @@ public:
   typedef itk::SmartPointer< Self >                  Pointer;
   typedef itk::SmartPointer< const Self >            ConstPointer;
 
-  typedef itk::Image< TInputPixel, Dimension >       InputImageType;
-  typedef typename InputImageType::Pointer           InputImagePointer;
-  typedef itk::GroupSpatialObject< Dimension >       TubeGroupType;
-  typedef typename TubeGroupType::Pointer            TubeGroupPointer;
   typedef itk::tube::SegmentTubesUsingMinimalPathFilter
-    < TubeGroupType, InputImageType >                FilterType;
-  typedef typename FilterType::PointType             PointType;
+    < Dimension, TInputPixel >                       FilterType;
+
+  typedef typename FilterType::InputImageType         InputImageType;
+  typedef typename InputImageType::Pointer            InputImagePointer;
+  typedef typename FilterType::InputSpatialObjectType TubeGroupType;
+  typedef typename TubeGroupType::Pointer             TubeGroupPointer;
+  typedef typename FilterType::PointType              PointType;
 
 
   /** Method for creation through the object factory. */
@@ -60,9 +61,8 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro( SegmentTubesUsingMinimalPath, Object );
 
-  /* Set input tubes */
-  tubeWrapSetMacro(Input, TubeGroupPointer, Filter );
-  tubeWrapGetConstObjectMacro(Input, TubeGroupType, Filter );
+  /* Set target tubes */
+  tubeWrapSetMacro( TargetTubeGroup, TubeGroupPointer, Filter );
 
   /** Set speed Image */
   tubeWrapSetMacro( SpeedImage, InputImagePointer, Filter );
@@ -78,15 +78,8 @@ public:
   /* Set end point for the path */
   tubeWrapSetMacro( EndPoint, PointType, Filter );
 
-  /* Set whether to extract the traget/end point
-  of the path from a target tube */
-  tubeWrapSetMacro( ExtractEndPointFromTargetTube, bool, Filter );
-
   /* Set if the extract path connects to the surface of the target tube */
   tubeWrapSetMacro( ConnectToTargetTubeSurface, bool, Filter );
-
-  /* Set whtheer to extract radius of the new tube. */
-  tubeWrapSetMacro( ExtractRadius, bool, Filter );
 
   /* Set Optimization method parameters. */
   tubeWrapSetMacro( OptimizationMethod, std::string, Filter );


### PR DESCRIPTION
ENH: Removed extra options from the application.
Since spatial object is an optional input to this application, the itk
filter should not be drived from SpatialObjectToSpatialObjectFilter.