### PR TITLE
BUG: itkSetMacro() handles only types that can be printed

### DIFF
--- a/Base/Numerics/itktubeComputeImageStatistics.h
+++ b/Base/Numerics/itktubeComputeImageStatistics.h
@@ -68,7 +68,7 @@ public:
   itkGetObjectMacro( InputMask, MaskType );
 
     /** Set/Get input mask */
-  itkSetMacro( Quantiles, std::vector<float> );
+  virtual void SetQuantiles( std::vector<float> _arg );
   itkGetMacro( Quantiles, std::vector<float> );
 
   /** Get Components */

--- a/Base/Numerics/itktubeComputeImageStatistics.hxx
+++ b/Base/Numerics/itktubeComputeImageStatistics.hxx
@@ -51,6 +51,18 @@ ComputeImageStatistics< TPixel, VDimension >
 template< class TPixel, unsigned int VDimension >
 void
 ComputeImageStatistics< TPixel, VDimension >
+::SetQuantiles (const std::vector<float> _arg)
+{
+  if( this->m_Quantiles != _arg )
+    {
+    this->m_Quantiles = _arg;
+    this->Modified();
+    }
+}
+
+template< class TPixel, unsigned int VDimension >
+void
+ComputeImageStatistics< TPixel, VDimension >
 ::GenerateData( void )
 {
   //Sanity checks


### PR DESCRIPTION
When compiling in Debug, itkSetMacro() calls itkDebugMacro() which
print the value of the variable that is set. If ones uses itkSetMacro
with a type that cannot directly be printed, compilation will
work in Release, but not in Debug.