### PR TITLE
BUG: ComputeTrainingMaskPythonTest ran with Python wrapping OFF

### DIFF
--- a/ITKModules/TubeTKITK/test/CMakeLists.txt
+++ b/ITKModules/TubeTKITK/test/CMakeLists.txt
@@ -15,24 +15,25 @@ set( CompareImages_EXE
  ${TubeTK_LAUNCHER} $<TARGET_FILE:CompareImages> )
 
 ######################  CompareTrainingMaskPython  ########################3
+if( ITK_WRAP_PYTHON )
+  set( MODULE_NAME ComputeTrainingMaskPython )
+  # Test1 - VesselMask
+  Midas3FunctionAddTest( NAME ${MODULE_NAME}-Test1
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_NAME}Test.py
+      MIDAS{ComputeTrainingMask-Test1.mha.md5}
+      ${TEMP}/${MODULE_NAME}_VesselMaskTest1.mha
+      ${TEMP}/${MODULE_NAME}_NotVesselMaskTest1.mha
+      0.5
+      2
+      )
 
-set(MODULE_NAME ComputeTrainingMaskPython)
-# Test1 - VesselMask
-Midas3FunctionAddTest( NAME ${MODULE_NAME}-Test1
-  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_NAME}Test.py
-    MIDAS{ComputeTrainingMask-Test1.mha.md5}
-    ${TEMP}/${MODULE_NAME}_VesselMaskTest1.mha
-    ${TEMP}/${MODULE_NAME}_NotVesselMaskTest1.mha
-    0.5
-    2
-    )
+  # Test1 - Compare - VesselMask
+  Midas3FunctionAddTest( NAME ${MODULE_NAME}-Test1-VesselMask-Compare
+    COMMAND ${CompareImages_EXE}
+      -t ${TEMP}/${MODULE_NAME}_VesselMaskTest1.mha
+      -b MIDAS{ComputeTrainingMask-Test1_VesselMask.mha.md5}
+      -i 0.01 )
 
-# Test1 - Compare - VesselMask
-Midas3FunctionAddTest( NAME ${MODULE_NAME}-Test1-VesselMask-Compare
-  COMMAND ${CompareImages_EXE}
-    -t ${TEMP}/${MODULE_NAME}_VesselMaskTest1.mha
-    -b MIDAS{ComputeTrainingMask-Test1_VesselMask.mha.md5}
-    -i 0.01 )
-
-set_property( TEST ${MODULE_NAME}-Test1-VesselMask-Compare
-  APPEND PROPERTY DEPENDS ${MODULE_NAME}-Test1 )
+  set_property( TEST ${MODULE_NAME}-Test1-VesselMask-Compare
+    APPEND PROPERTY DEPENDS ${MODULE_NAME}-Test1 )
+endif()

--- a/ITKModules/TubeTKITK/test/ComputeTrainingMaskPythonTest.py
+++ b/ITKModules/TubeTKITK/test/ComputeTrainingMaskPythonTest.py
@@ -1,6 +1,41 @@
 #!/usr/bin/env python
 
-import itk
+import os
+import sys
+
+
+# Path for TubeTK libs
+TubeTK_BUILD_DIR=None
+if 'TubeTK_BUILD_DIR' in os.environ:
+    TubeTK_BUILD_DIR = os.environ['TubeTK_BUILD_DIR']
+if not os.path.exists(TubeTK_BUILD_DIR):
+    print('TubeTK_BUILD_DIR not found!')
+    print('  Set environment variable')
+    sys.exit(1)
+
+try:
+    import itk
+except:
+    ITK_BUILD_DIR = None
+    if 'ITK_BUILD_DIR' in os.environ:
+        ITK_BUILD_DIR = os.environ['ITK_BUILD_DIR']
+    else:
+        print('ITK_BUILD_DIR not found!')
+        print('  Set environment variable')
+        sys.exit( 1 )
+
+    if not os.path.exists(ITK_BUILD_DIR):
+        print('ITK_BUILD_DIR set by directory not found!')
+        print('  ITK_BUIDL_DIR = ' + ITK_BUILD_DIR )
+        sys.exit(1)
+    # Append ITK libs
+    sys.path.append(os.path.join(ITK_BUILD_DIR, 'Wrapping/Generators/Python'))
+    sys.path.append(os.path.join(ITK_BUILD_DIR, 'lib'))
+
+    # Append TubeTK libs
+    sys.path.append(os.path.join(TubeTK_BUILD_DIR, 'TubeTK-build/lib/TubeTK'))
+    import itk
+
 from itk import TubeTKITK
 import sys
 


### PR DESCRIPTION
ComputeTrainingMaskPythonTest should not be running if Python wrapping
is disabled. Paths to include itk and TubeTKITK within the test
have been updated to rely on environment variables.