### PR TITLE
ENH: Set environment variables for Python tests

### DIFF
--- a/CMake/Midas3FunctionAddTest.cmake
+++ b/CMake/Midas3FunctionAddTest.cmake
@@ -65,6 +65,7 @@
 #   The MIDAS*{} substitution methods can also be passed a relative path from
 #   the MIDAS_KEY_DIR to the key file, so that you can place key files in
 #   subdirectories under MIDAS_KEY_DIR. Ex: MIDAS{test1/input/foo.png.md5}
+include(CMakeParseArguments)
 
 function( Midas3FunctionAddTest )
   # Determine the test name.
@@ -157,6 +158,36 @@ set( midas_test_name \"${testName}\" )
   add_test( ${testArgs} )
   set_property( TEST ${testName} APPEND PROPERTY DEPENDS ${testName}_fetchData )
 endfunction( Midas3FunctionAddTest )
+
+
+# This function accepts 3 arguments:
+# - NAME
+# - ENVIRONMENT
+# - COMMAND
+#
+# It relies on Midas3FunctionAddTest (see documentation above) and adds
+# the possibility to set environment variables for a test. Environment
+# variables should be passed as different arguments
+# of the form "NAME=VALUE"
+#
+# Example:
+#
+# ENVIRONMENT ITK_BUILD_DIR=${ITK_DIR} TubeTK_BUILD_DIR=${PROJECT_BINARY_DIR}
+#
+# Unparsed arguments are passed to Midas3FunctionAddTest unchanged.
+#
+function( Midas3FunctionAddTestWithEnv )
+  set(options )
+  set(oneValueArgs NAME )
+  set(multiValueArgs ENVIRONMENT COMMAND)
+  cmake_parse_arguments(ENV_TEST "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+  Midas3FunctionAddTest( NAME ${ENV_TEST_NAME} COMMAND ${ENV_TEST_COMMAND} ${ENV_TEST_UNPARSED_ARGUMENTS} )
+  foreach(var ${ENV_TEST_ENVIRONMENT})
+    list(APPEND env_list ${var})
+  endforeach()
+  set_tests_properties(${ENV_TEST_NAME} PROPERTIES ENVIRONMENT "${env_list}")
+endfunction( Midas3FunctionAddTestWithEnv )
+
 
 # Helper macro to write the download scripts for MIDAS.*{} arguments
 macro( _process_keyfile keyFile testName extractTgz )

--- a/CMake/TubeTKTestEnvironmentVariables.cmake
+++ b/CMake/TubeTKTestEnvironmentVariables.cmake
@@ -21,12 +21,19 @@
 #
 ##############################################################################
 
-Midas3FunctionAddTestWithEnv( NAME Python.MergeAdjacentImages
-  COMMAND ${PYTHON_TESTING_EXECUTABLE}
-    "${NOTEBOOK_TEST_DRIVER}"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../MergeAdjacentImages.ipynb"
-    "${TubeTK_BINARY_DIR}"
-    MIDAS_FETCH_ONLY{ES0015_Large.mha.md5}
-    MIDAS_FETCH_ONLY{ES0015_Large_Wo_offset.mha.md5}
-  ENVIRONMENT ITK_BUILD_DIR=${ITK_DIR} TubeTK_BUILD_DIR=${PROJECT_BINARY_DIR}
-  )
+# This script expects ITK_BUILD_DIR and TubeTK_BUILD_DIR to be passed as cmake
+# variables.
+# It verifies that ITK_BUILD_DIR and TubeTK_BUILD_DIR are set as environment
+# variables and that their values match the values passed to the script.
+if( DEFINED $ENV{ITK_BUILD_DIR})
+  message(FATAL_ERROR "ITK_BUILD_DIR environment variable not set.")
+endif()
+if(NOT "$ENV{ITK_BUILD_DIR}" STREQUAL "${ITK_BUILD_DIR}")
+  message(FATAL_ERROR "ITK_BUILD_DIR environment variable does not match ITK_DIR set in this project.")
+endif()
+if( DEFINED $ENV{TubeTK_BUILD_DIR})
+  message(FATAL_ERROR "TubeTK_BUILD_DIR environment variable not set.")
+endif()
+if(NOT "$ENV{TubeTK_BUILD_DIR}" STREQUAL "${TubeTK_BUILD_DIR}")
+  message(FATAL_ERROR "TubeTK_BUILD_DIR environment variable does not match current directory path.")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -708,6 +708,10 @@ if( TubeTK_BUILD_USING_SLICER )
   add_subdirectory( SlicerModules )
 endif( TubeTK_BUILD_USING_SLICER )
 
+if( BUILD_TESTING )
+  add_subdirectory( Testing )
+endif( BUILD_TESTING )
+
 # Create the directory where CTest unit tests store temporary results.
 make_directory( ${TubeTK_BINARY_DIR}/Temporary )
 

--- a/Examples/TubeNumPyArray/Testing/CMakeLists.txt
+++ b/Examples/TubeNumPyArray/Testing/CMakeLists.txt
@@ -21,9 +21,11 @@
 #
 ##############################################################################
 
-Midas3FunctionAddTest( NAME Python.TubeNumPyArrayAndPropertyHistograms
+Midas3FunctionAddTestWithEnv( NAME Python.TubeNumPyArrayAndPropertyHistograms
   COMMAND ${PYTHON_TESTING_EXECUTABLE}
     "${NOTEBOOK_TEST_DRIVER}"
     "${CMAKE_CURRENT_SOURCE_DIR}/../TubeNumPyArrayAndPropertyHistograms.ipynb"
     "${TubeTK_BINARY_DIR}"
-    MIDAS{VascularNetwork.tre.md5} )
+    MIDAS{VascularNetwork.tre.md5}
+  ENVIRONMENT ITK_BUILD_DIR=${ITK_DIR} TubeTK_BUILD_DIR=${PROJECT_BINARY_DIR}
+  )

--- a/ITKModules/TubeTKITK/test/CMakeLists.txt
+++ b/ITKModules/TubeTKITK/test/CMakeLists.txt
@@ -18,13 +18,14 @@ set( CompareImages_EXE
 if( ITK_WRAP_PYTHON )
   set( MODULE_NAME ComputeTrainingMaskPython )
   # Test1 - VesselMask
-  Midas3FunctionAddTest( NAME ${MODULE_NAME}-Test1
+  Midas3FunctionAddTestWithEnv( NAME ${MODULE_NAME}-Test1
     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_NAME}Test.py
       MIDAS{ComputeTrainingMask-Test1.mha.md5}
       ${TEMP}/${MODULE_NAME}_VesselMaskTest1.mha
       ${TEMP}/${MODULE_NAME}_NotVesselMaskTest1.mha
       0.5
       2
+    ENVIRONMENT ITK_BUILD_DIR=${ITK_DIR} TubeTK_BUILD_DIR=${PROJECT_BINARY_DIR}
       )
 
   # Test1 - Compare - VesselMask

--- a/ITKModules/TubeTKITK/test/ComputeTrainingMaskPythonTest.py
+++ b/ITKModules/TubeTKITK/test/ComputeTrainingMaskPythonTest.py
@@ -8,8 +8,13 @@ import sys
 TubeTK_BUILD_DIR=None
 if 'TubeTK_BUILD_DIR' in os.environ:
     TubeTK_BUILD_DIR = os.environ['TubeTK_BUILD_DIR']
-if not os.path.exists(TubeTK_BUILD_DIR):
+else:
     print('TubeTK_BUILD_DIR not found!')
+    print('  Set environment variable')
+    sys.exit(1)
+
+if not os.path.exists(TubeTK_BUILD_DIR):
+    print('TubeTK_BUILD_DIR set by directory not found!')
     print('  Set environment variable')
     sys.exit(1)
 

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Test that environment variables are set and correspond to this environment
+option( TubeTK_TEST_ENVIRONMENT
+  "Test that environment variables ITK_BUILD_DIR and TubeTK_BUILD_DIR are set and correspond to this project." ON )
+if( TubeTK_TEST_ENVIRONMENT )
+  add_test( NAME TestEnvironmentVariables
+            COMMAND ${CMAKE_COMMAND} -DITK_BUILD_DIR:PATH=${ITK_DIR} -DTubeTK_BUILD_DIR:PATH=${PROJECT_BINARY_DIR}
+                    -P ${PROJECT_SOURCE_DIR}/CMake/TubeTKTestEnvironmentVariables.cmake )
+endif()


### PR DESCRIPTION
When running python scripts that use TubeTK wrapped in Python,
one needs to set their environment so that the libraries are loaded.
This can be done two ways:
-Copy WrapITK.pth from TubeTK-build/Generators/Python/ or setting
ITK_BUILD_DIR and TubeTK_BUILD_DIR environment variables. Because tests
are develop to verify that TubeTK works correctly, they replicate the
expected behavior of a user. Python tests set these two environment
variables before running the tests. This is done by calling the
new TubeTK function Midas3FunctionWithEnvAddTest.
Additionally, a test has been added to verify that the environment
variables are set on the system and match the expected value
of these variables in this project. This test can be deactivated
by setting TubeTK_TEST_ENVIRONMENT to OFF (e.g. on a Dashboard
machine compiling multiple versions of TubeTK).
on the current computer, they should behave the way a user
would expect their own too