### PR TITLE
BUG: Minimal path segmentation doesn't handle output correctly

### DIFF
--- a/Base/Segmentation/itktubeSegmentTubesUsingMinimalPathFilter.hxx
+++ b/Base/Segmentation/itktubeSegmentTubesUsingMinimalPathFilter.hxx
@@ -225,12 +225,8 @@ SegmentTubesUsingMinimalPathFilter< Dimension, TInputPixel >
           continue;
           }
         }
-      for( unsigned int d = 0; d < Dimension; d++ )
-        {
-        pathPoint[d]=( pathPoint[d] - origin[d] ) / spacing[d];
-        }
       TubePointType tubePoint;
-      tubePoint.SetPosition( pathPoint );
+      tubePoint.SetPosition( vertexList->GetElement( k ) );
       tubePoint.SetID( k );
       tubePointList.push_back( tubePoint );
       }


### PR DESCRIPTION
The code converts a vertex (an index) to a physical point then converts back to an index manually.  This seems redundant and causes the output to be incorrect for images with non-standard scan order.