### PR TITLE
COMP: CircleCI compiler crash because container runs out of memory

### DIFF
--- a/CMake/CircleCI/CircleCI_slicer_Docker.cmake
+++ b/CMake/CircleCI/CircleCI_slicer_Docker.cmake
@@ -27,6 +27,9 @@ set( SITE_NAME "CircleCI_Slicer_GitHub" )
 # Follow format for caps and components as given on TubeTK dashboard
 set( SITE_PLATFORM "Ubuntu-14.04-64" )
 
+# Use SITE_BUILD_TYPE specified by circle.yml
+set( SITE_BUILD_TYPE "$ENV{SITE_BUILD_TYPE}" )
+
 if( NOT SITE_BUILD_TYPE )
   set( SITE_BUILD_TYPE "Release" ) # Release, Debug
 endif( NOT SITE_BUILD_TYPE )
@@ -39,7 +42,7 @@ if( NOT SITE_CTEST_MODE )
   set( SITE_CTEST_MODE "Experimental" ) # Experimental, Continuous, or Nightly
 endif( NOT SITE_CTEST_MODE )
 
-set( SITE_CMAKE_GENERATOR "Ninja" ) # Ninja or Unix Makefiles
+set( SITE_CMAKE_GENERATOR "Unix Makefiles" ) # Ninja or Unix Makefiles
 
 set( TubeTK_GIT_REPOSITORY "https://github.com/KitwareMedical/TubeTK.git" )
 
@@ -102,10 +105,11 @@ set( BUILD_SHARED_LIBS ON )
 
 set( ENV{DISPLAY} ":0" )
 
-set( SITE_MAKE_COMMAND "ninja" )
+set( CTEST_BUILD_FLAGS "-j 3" )
 
 set( SITE_CMAKE_COMMAND "/usr/bin/cmake" )
-set( SITE_CTEST_COMMAND "/usr/bin/ctest -j3" )
+
+set( CTEST_PARALLEL_LEVEL 3 )
 
 set( SITE_QMAKE_COMMAND "/usr/bin/qmake" )
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,7 @@ machine:
     - docker
   environment:
     DOCKER_TAG_1: slicer
+    SITE_BUILD_TYPE: Release
 
 dependencies:
   override:
@@ -11,5 +12,5 @@ dependencies:
 
 test:
   override:
-    - docker run -e CIRCLE_SHA1=$CIRCLE_SHA1 -e CIRCLE_BRANCH=$CIRCLE_BRANCH -v ~/TubeTK:/usr/src/TubeTK -v ~/TubeTK-build:/usr/src/TubeTK-build kitwaremedical/tubetk:$DOCKER_TAG_1 /usr/src/TubeTK/CMake/CircleCI/CircleCI_TubeTK_Experimental.sh $DOCKER_TAG_1 :
+    - docker run -e CIRCLE_SHA1=$CIRCLE_SHA1 -e CIRCLE_BRANCH=$CIRCLE_BRANCH -e SITE_BUILD_TYPE=$SITE_BUILD_TYPE -v ~/TubeTK:/usr/src/TubeTK -v ~/TubeTK-$SITE_BUILD_TYPE:/usr/src/TubeTK-$SITE_BUILD_TYPE kitwaremedical/tubetk:$DOCKER_TAG_1 /usr/src/TubeTK/CMake/CircleCI/CircleCI_TubeTK_Experimental.sh $DOCKER_TAG_1 :
         timeout: 6000


### PR DESCRIPTION
CircleCI build are constrained by a 4Gb memory limit. See
https://circleci.com/docs/oom/

The compiler checks for the number of cores available on the machine.
The output of "lscpu" shows 32 cores on the entire machine. However,
builds are running in a single container that shares cores with other
currently running containers.
The output of "top" shows that the compiler try to use all cores
and can dedicate up to 1Gb of memory for each job :

  PID  USER      PR  NI  VIRT  RES  SHR S %CPU %MEM    TIME+  COMMAND
 17714 root      20   0  622m 578m  11m R   12  0.2   0:42.30 cc1plus
 17797 root      20   0  692m 647m  11m R   12  0.3   0:39.37 cc1plus
 [...]
 17570 root      20   0  840m 791m  11m R    4  0.3   0:46.91 cc1plus
 17723 root      20   0  729m 682m  10m R    4  0.3   0:38.86 cc1plus
 17864 root      20   0  664m 626m 6556 R    4  0.3   0:32.73 cc1plus

The 4Gb limit is reached quickly and jobs are randomly killed, throwing
the following output:
  c++: internal compiler error: Killed (program cc1plus)

Even with argument -j1, Ninja is still using all cores.
SITE_CMAKE_GENERATOR has been changed to "Unix Makefiles" and
SITE_MAKE_COMMAND has been changed to "make -j3" to limit memory usage.

${SITE_BUILD_TYPE} is now specified by circle.yml in order to fix the
build directory that was mounted on the machine. It was not reachable
because of name inconsistency.
Default is set to Release.