### PR TITLE
BUG: Fixed loss of precision when reading and storing points

### DIFF
--- a/SlicerModules/SpatialObjectsModule/MRML/vtkMRMLSpatialObjectsNode.cxx
+++ b/SlicerModules/SpatialObjectsModule/MRML/vtkMRMLSpatialObjectsNode.cxx
@@ -460,6 +460,7 @@ void vtkMRMLSpatialObjectsNode::UpdatePolyDataFromSpatialObject( void )
     }
   // Create the points
   vtkNew<vtkPoints> vesselsPoints;
+  vesselsPoints->SetDataTypeToDouble();
   vesselsPoints->SetNumberOfPoints(totalNumberOfPoints);
 
   // Create the Lines


### PR DESCRIPTION
Points are being read as double but vtkPoints stores floats by default.  This loss of precision can cause very close points to become coincident.