### PR TITLE
BUG: Wrong path TubeTK_BUILD_DIR

### DIFF
--- a/ITKModules/TubeTKITK/test/CMakeLists.txt
+++ b/ITKModules/TubeTKITK/test/CMakeLists.txt
@@ -25,7 +25,7 @@ if( ITK_WRAP_PYTHON )
       ${TEMP}/${MODULE_NAME}_NotVesselMaskTest1.mha
       0.5
       2
-    ENVIRONMENT ITK_BUILD_DIR=${ITK_DIR} TubeTK_BUILD_DIR=${PROJECT_BINARY_DIR}
+    ENVIRONMENT ITK_BUILD_DIR=${ITK_DIR} TubeTK_BUILD_DIR=${TubeTK_BINARY_DIR}
       )
 
   # Test1 - Compare - VesselMask

--- a/ITKModules/TubeTKITK/test/ComputeTrainingMaskPythonTest.py
+++ b/ITKModules/TubeTKITK/test/ComputeTrainingMaskPythonTest.py
@@ -4,20 +4,6 @@ import os
 import sys
 
 
-# Path for TubeTK libs
-TubeTK_BUILD_DIR=None
-if 'TubeTK_BUILD_DIR' in os.environ:
-    TubeTK_BUILD_DIR = os.environ['TubeTK_BUILD_DIR']
-else:
-    print('TubeTK_BUILD_DIR not found!')
-    print('  Set environment variable')
-    sys.exit(1)
-
-if not os.path.exists(TubeTK_BUILD_DIR):
-    print('TubeTK_BUILD_DIR set by directory not found!')
-    print('  Set environment variable')
-    sys.exit(1)
-
 try:
     import itk
 except:
@@ -31,17 +17,37 @@ except:
 
     if not os.path.exists(ITK_BUILD_DIR):
         print('ITK_BUILD_DIR set by directory not found!')
-        print('  ITK_BUIDL_DIR = ' + ITK_BUILD_DIR )
+        print('  ITK_BUILD_DIR = ' + ITK_BUILD_DIR )
         sys.exit(1)
     # Append ITK libs
     sys.path.append(os.path.join(ITK_BUILD_DIR, 'Wrapping/Generators/Python'))
     sys.path.append(os.path.join(ITK_BUILD_DIR, 'lib'))
 
-    # Append TubeTK libs
-    sys.path.append(os.path.join(TubeTK_BUILD_DIR, 'TubeTK-build/lib/TubeTK'))
     import itk
 
-from itk import TubeTKITK
+try:
+    from itk import TubeTKITK
+except:
+    # Path for TubeTK libs
+    TubeTK_BUILD_DIR=None
+    if 'TubeTK_BUILD_DIR' in os.environ:
+        TubeTK_BUILD_DIR = os.environ['TubeTK_BUILD_DIR']
+    else:
+        print('TubeTK_BUILD_DIR not found!')
+        print('  Set environment variable')
+        sys.exit(1)
+
+    if not os.path.exists(TubeTK_BUILD_DIR):
+        print('TubeTK_BUILD_DIR set by directory not found!')
+        print('  Set environment variable')
+        sys.exit(1)
+
+    # Append TubeTK libs
+    sys.path.append(os.path.join(TubeTK_BUILD_DIR, 'Wrapping/Generators/Python'))
+    sys.path.append(os.path.join(TubeTK_BUILD_DIR, 'lib'))
+
+    from itk import TubeTKITK
+
 import sys
 
 def main():


### PR DESCRIPTION
To test TubeTKITK wrapped in Python, we setup the environment
variable TubeTK_BUILD_DIR. This variable was set to the wrong
path: It was set using the CMake variable PROJECT_BINARY_DIR
which was not pointing to TubeTK inner build directory
but rather to the TubeTK wrapping directory.