### PR TITLE
BUG: Make TubeTK_USE_EXAMPLES_AS_TESTS as an option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,7 +519,7 @@ endif( BUILD_TESTING AND TubeTK_USE_PYTHON AND NOT TubeTK_BUILD_USING_SLICER )
 #
 # Testing using Examples
 #
-set( TubeTK_USE_EXAMPLES_AS_TESTS "Use TubeTK examples as (long running) tests."
+option( TubeTK_USE_EXAMPLES_AS_TESTS "Use TubeTK examples as (long running) tests."
   OFF )
 
 #


### PR DESCRIPTION
Also, the usage of the set command for this option was incorrect. The [syntax](https://cmake.org/cmake/help/v3.0/command/set.html) of cmake's set command is

```
set(<variable> <value>
    [[CACHE <type> <docstring> [FORCE]] | PARENT_SCOPE])
```