### PR TITLE
Improve compatibility with 3D Slicer

### DIFF
--- a/Base/Registration/itktubeAnisotropicDiffusiveSparseRegistrationFilter.hxx
+++ b/Base/Registration/itktubeAnisotropicDiffusiveSparseRegistrationFilter.hxx
@@ -741,9 +741,14 @@ AnisotropicDiffusiveSparseRegistrationFilter
       // tube centerline point and its two normals, and consider the distance
       // to the surface via the radius.
       float normal1[ImageDimension];
-      tubeNormal1Data->GetTupleValue( tubeId, normal1 );
       float normal2[ImageDimension];
-      tubeNormal2Data->GetTupleValue( tubeId, normal2 );
+#if VTK_MAJOR_VERSION < 7
+      tubeNormal1Data->GetTupleValue(tubeId, normal1);
+      tubeNormal2Data->GetTupleValue(tubeId, normal2);
+#else
+      tubeNormal1Data->GetTypedTuple(tubeId, normal1);
+      tubeNormal2Data->GetTypedTuple(tubeId, normal2);
+#endif
 
       double distanceToCenterCoord = ComputeDistanceToPointOnPlane(
             centerlineCoord, normal1, normal2, imageCoord );

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,12 @@ option( TubeTK_BUILD_WITHIN_SLICER
   "Whether TubeTK's CLIs modules are configured to be run from Slicer or alone."
   OFF )
 mark_as_advanced( TubeTK_BUILD_WITHIN_SLICER )
+# Slicer's extension build tool defines TubeTK_BUILD_SLICER_EXTENSION
+# to indicate that this project has to be compiled using Slicer, within Slicer.
+if( TubeTK_BUILD_SLICER_EXTENSION )
+  set(TubeTK_BUILD_USING_SLICER TRUE)
+  set(TubeTK_BUILD_WITHIN_SLICER TRUE)
+endif()
 if( TubeTK_BUILD_USING_SLICER )
   include( TubeTKSlicer4ExtensionConfig )
 


### PR DESCRIPTION
These are two minor changes that improves compatibility with latest version of 3D Slicer.

One change is just to make TubeTK compatible with a changed API in VTK7.

The other change is to facilitate building of TubeTK as an extension by Slicer factory machines. It only fixes build errors, there are still issues in building the extension package.