### PR TITLE
BUG: Testing Python module on Windows requires knowing configuration

### DIFF
--- a/ITKModules/TubeTKITK/test/CMakeLists.txt
+++ b/ITKModules/TubeTKITK/test/CMakeLists.txt
@@ -33,7 +33,6 @@ set( CompareImages_EXE ${TubeTK_LAUNCHER} $<TARGET_FILE:CompareImages> )
 
 ######################  PythonComputeTrainingMask  ##########################
 if( ITK_WRAP_PYTHON )
-
   # Test1 - PythonComputeTrainingMask
   set( MODULE_NAME PythonComputeTrainingMask )
   Midas3FunctionAddTestWithEnv( NAME TubeTKITK.Python.ComputeTrainingMask-Test1
@@ -44,7 +43,7 @@ if( ITK_WRAP_PYTHON )
         ${TEMP}/${MODULE_NAME}_NotVesselMaskTest1.mha
         0.5
         2
-    ENVIRONMENT ITK_BUILD_DIR=${ITK_DIR} TubeTK_BUILD_DIR=${TubeTK_BINARY_DIR}
+    ENVIRONMENT ITK_BUILD_DIR=${ITK_DIR} TubeTK_BUILD_DIR=${TubeTK_BINARY_DIR} BUILD_TYPE=$<$<BOOL:${WIN32}>:$<CONFIG>>
     )
   # Test1 - Compare - PythonComputeTrainingMask
   Midas3FunctionAddTest( NAME

--- a/ITKModules/TubeTKITK/test/PythonComputeTrainingMaskTest.py
+++ b/ITKModules/TubeTKITK/test/PythonComputeTrainingMaskTest.py
@@ -3,75 +3,71 @@
 import os
 import sys
 
-
-try:
-    import itk
-except:
-    ITK_BUILD_DIR = None
-    if 'ITK_BUILD_DIR' in os.environ:
-        ITK_BUILD_DIR = os.environ['ITK_BUILD_DIR']
+def GetRequiredEnvironmentVariable( varName ):
+    if varName in os.environ:
+        return os.environ[ varName ]
     else:
-        print('ITK_BUILD_DIR not found!')
-        print('  Set environment variable')
+        print( '%s not found!' )%varName
+        print( '  Set environment variable' )
         sys.exit( 1 )
 
-    if not os.path.exists(ITK_BUILD_DIR):
-        print('ITK_BUILD_DIR set by directory not found!')
-        print('  ITK_BUILD_DIR = ' + ITK_BUILD_DIR )
-        sys.exit(1)
-    # Append ITK libs
-    sys.path.append(os.path.join(ITK_BUILD_DIR, 'Wrapping/Generators/Python'))
-    sys.path.append(os.path.join(ITK_BUILD_DIR, 'lib'))
+def CheckIfPathExists( path, name ):
+    if not os.path.exists( path ):
+        print( 'Directory not found!' )
+        print( '  %s = %s' )%( name, path )
+        sys.exit( 1 )
 
-    import itk
+def AppendSysPath( path ):
+    BUILD_TYPE = GetRequiredEnvironmentVariable( 'BUILD_TYPE' )
+    # Append path libs
+    sys.path.append( os.path.join( os.path.join( path, \
+                               'Wrapping/Generators/Python' ), BUILD_TYPE ) )
+    # Folder containing *py files (and *a/*so files on Linux)
+    sys.path.append( os.path.join( path, 'lib') )
+    # Folder containing *lib files on Windows
+    sys.path.append( os.path.join( os.path.join( path, \
+                                   'lib' ), BUILD_TYPE) )
+    # Windows needs this to load the DLL's
+    os.environ[ 'PATH' ] += os.pathsep \
+                         + os.path.join( os.path.join( path, 'bin' ),\
+                         BUILD_TYPE )
 
-try:
-    from itk import TubeTKITK
-except:
-    # Path for TubeTK libs
-    TubeTK_BUILD_DIR=None
-    if 'TubeTK_BUILD_DIR' in os.environ:
-        TubeTK_BUILD_DIR = os.environ['TubeTK_BUILD_DIR']
-    else:
-        print('TubeTK_BUILD_DIR not found!')
-        print('  Set environment variable')
-        sys.exit(1)
+# Path for ITK
+ITK_BUILD_DIR = GetRequiredEnvironmentVariable( 'ITK_BUILD_DIR' )
+CheckIfPathExists( ITK_BUILD_DIR, 'ITK_BUILD_DIR' )
+AppendSysPath( ITK_BUILD_DIR )
+# Path for TubeTK libs
+TubeTK_BUILD_DIR = GetRequiredEnvironmentVariable( 'TubeTK_BUILD_DIR' )
+CheckIfPathExists( TubeTK_BUILD_DIR, 'TubeTK_BUILD_DIR' )
+AppendSysPath( TubeTK_BUILD_DIR )
 
-    if not os.path.exists(TubeTK_BUILD_DIR):
-        print('TubeTK_BUILD_DIR set by directory not found!')
-        print('  Set environment variable')
-        sys.exit(1)
-
-    # Append TubeTK libs
-    sys.path.append(os.path.join(TubeTK_BUILD_DIR, 'Wrapping/Generators/Python'))
-    sys.path.append(os.path.join(TubeTK_BUILD_DIR, 'lib'))
-
-    from itk import TubeTKITK
-
-import sys
+import itk
+from itk import TubeTKITK
 
 def main():
-  if len(sys.argv) != 6:
-    print("Usage: %s InputImage OutputVesselMask OutputNotVesselMask gap notVesselWidth"%sys.argv[0])
+  if len( sys.argv ) != 6:
+    print( "Usage: %s InputImage OutputVesselMask OutputNotVesselMask gap\
+            notVesselWidth"%sys.argv[0] )
     return 1
-  inputImage=sys.argv[1]
-  outputVesselMask=sys.argv[2]
-  outputNotVesselMask=sys.argv[3]
-  gap=float(sys.argv[4])
-  notVesselWidth=float(sys.argv[5])
+  inputImage = sys.argv[1]
+  outputVesselMask = sys.argv[2]
+  outputNotVesselMask = sys.argv[3]
+  gap=float( sys.argv[4] )
+  notVesselWidth=float( sys.argv[5] )
 
-  reader=itk.ImageFileReader.New(FileName=inputImage)
+  reader=itk.ImageFileReader.New( FileName=inputImage )
   reader.Update()
-  trainingMask=TubeTKITK.ComputeTrainingMask.New(reader)
+  trainingMask=TubeTKITK.ComputeTrainingMask.New( reader )
   trainingMask.SetGap(gap)
-  trainingMask.SetNotVesselWidth(notVesselWidth)
+  trainingMask.SetNotVesselWidth( notVesselWidth )
   trainingMask.Update()
-  writer=itk.ImageFileWriter.New(trainingMask,FileName=outputVesselMask)
+  writer=itk.ImageFileWriter.New( trainingMask, FileName=outputVesselMask )
   writer.Update()
 
-  writer=itk.ImageFileWriter.New(trainingMask.GetNotVesselMask(),FileName=outputNotVesselMask)
+  writer=itk.ImageFileWriter.New( trainingMask.GetNotVesselMask(),\
+                                  FileName=outputNotVesselMask )
   writer.Update()
 
 
 if __name__ == "__main__":
-  sys.exit(main())
+  sys.exit( main() )


### PR DESCRIPTION
The paths of the directory containing WrapITK.pth files required to import
ITK and TubeTK in Python on Windows contain the configuration that is chosen
at build time.