### PR TITLE
BUG: TubeTKIO library is now simply an interface - no library created

### DIFF
--- a/Base/IO/CMakeLists.txt
+++ b/Base/IO/CMakeLists.txt
@@ -43,18 +43,13 @@ if( TubeTK_USE_LIBSVM )
     itktubePDFSegmenterSVMIO.hxx )
 endif( TubeTK_USE_LIBSVM )
 
-set( TubeTK_Base_IO_SRCS )
+add_library( ${PROJECT_NAME} INTERFACE )
 
-add_library( ${PROJECT_NAME} STATIC
-  ${TubeTK_Base_IO_H_Files}
-  ${TubeTK_Base_IO_HXX_Files}
-  ${TubeTK_Base_IO_SRCS} )
-
-target_link_libraries( ${PROJECT_NAME} PUBLIC
+target_link_libraries( ${PROJECT_NAME} INTERFACE
   TubeTKMetaIO TubeTKCommon TubeTKNumerics TubeTKSegmentation )
 
-target_include_directories( ${PROJECT_NAME} PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR} )
+target_include_directories( ${PROJECT_NAME} INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>" )
 
 if( TubeTK_BUILD_TESTING )
   add_subdirectory( Testing )


### PR DESCRIPTION
TubeTKIO directory no longer has non-templated code, so no TubeTKIO library is created.

Using "modern cmake" we define TubeTKIO as an INTERFACE.

It may be necessary to delete cmake caches (e.g., reconfigure and rebuild from scratch) after this commit.