### PR TITLE
BUG: ResampleImages and PrintSelf for wrapped functions

### DIFF
--- a/Applications/ResampleImage/ResampleImage.cxx
+++ b/Applications/ResampleImage/ResampleImage.cxx
@@ -35,7 +35,8 @@ limitations under the License.
 template< class TPixel, unsigned int VDimension >
 int DoIt( int argc, char * argv[] );
 
-// Must follow include of "...CLP.h" and forward declaration of int DoIt( ... ).
+// Must follow include of "...CLP.h" and forward declaration of
+//   int DoIt( ... ).
 #include "tubeCLIHelperFunctions.h"
 
 template< class TPixel, unsigned int DimensionI >
@@ -43,8 +44,8 @@ int DoIt( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  typedef typename tube::ResampleImage< TPixel,
-          DimensionI >                           FilterType;
+  typedef typename tube::ResampleImage< TPixel, DimensionI >
+                                                 FilterType;
   typename FilterType::Pointer filter = FilterType::New();
 
   typedef typename FilterType::ImageType         ImageType;
@@ -131,6 +132,7 @@ int DoIt( int argc, char * argv[] )
   reporter.Report( 0.25 );
 
   filter->Update();
+
   outIm = filter->GetOutput();
 
   reporter.Report( 0.95 );

--- a/Base/Filtering/itktubeResampleImageFilter.hxx
+++ b/Base/Filtering/itktubeResampleImageFilter.hxx
@@ -159,13 +159,16 @@ GenerateData( void )
       }
     }
 
-  std::vector< double > outResampleFactor;
-  outResampleFactor.resize( VDimension );
-  for( unsigned int i = 0; i< VDimension; i++ )
+  if( !m_MatchImage )
     {
-    outResampleFactor[i] = inSpacing[i] / outSpacing[i];
-    outSize[i] = static_cast<unsigned long>( inSize[i]
-                                            * outResampleFactor[i] );
+    std::vector< double > outResampleFactor;
+    outResampleFactor.resize( VDimension );
+    for( unsigned int i = 0; i< VDimension; i++ )
+      {
+      outResampleFactor[i] = inSpacing[i] / outSpacing[i];
+      outSize[i] = static_cast<unsigned long>( inSize[i]
+                                              * outResampleFactor[i] );
+      }
     }
 
   typedef typename itk::ResampleImageFilter< ImageType, ImageType >

--- a/Base/Filtering/itktubeResampleImageFilter.hxx
+++ b/Base/Filtering/itktubeResampleImageFilter.hxx
@@ -38,9 +38,15 @@ ResampleImageFilter< TPixel, VDimension >::
 ResampleImageFilter( void )
 {
   m_MatchImage = NULL;
-  m_LoadTransform = false;
-  m_MakeHighResIso = false;
+  m_Spacing.clear();
+  m_Origin.clear();
+  m_Index.clear();
+  m_ResampleFactor.clear();
   m_MakeIsotropic = false;
+  m_MakeHighResIso = false;
+  m_Interpolator = "Linear";
+  m_LoadTransform = false;
+  m_Transform = NULL;
 }
 
 /** GenerateData */
@@ -50,7 +56,6 @@ ResampleImageFilter< TPixel, VDimension >::
 GenerateData( void )
 {
   const ImageType *inputImage = this->GetInput();
-  ImageType *outputImage = this->GetOutput( 0 );
 
   typename ImageType::SpacingType     inSpacing = inputImage->GetSpacing();
   typename ImageType::PointType       inOrigin = inputImage->GetOrigin();
@@ -84,13 +89,7 @@ GenerateData( void )
     outSize = m_MatchImage->GetLargestPossibleRegion().GetSize();
     outIndex = m_MatchImage->GetLargestPossibleRegion().GetIndex();
     }
-  if( m_Spacing.size() > 0 )
-    {
-    for( unsigned int i = 0; i < VDimension; i++ )
-      {
-      outSpacing[i] = m_Spacing[i];
-      }
-    }
+
   if( m_Origin.size() > 0 )
     {
     for( unsigned int i = 0; i < VDimension; i++ )
@@ -105,18 +104,24 @@ GenerateData( void )
       outIndex[i] = m_Index[i];
       }
     }
-  if( m_ResampleFactor.size() > 0 )
+  if( m_Spacing.size() > 0 )
+    {
+    for( unsigned int i = 0; i < VDimension; i++ )
+      {
+      outSpacing[i] = m_Spacing[i];
+      }
+    }
+  else if( m_ResampleFactor.size() > 0 )
     {
     for( unsigned int i = 0; i < VDimension; i++ )
       {
       outSpacing[i] = outSpacing[i] / m_ResampleFactor[i];
       }
     }
-  if( m_MakeIsotropic )
+  else if( m_MakeIsotropic )
     {
-    typedef itk::CompensatedSummation< double > CompensatedSummationType;
-    CompensatedSummationType iso;
-    for( unsigned int i = 0; i < VDimension - 1; i++ )
+    double iso = outSpacing[0];
+    for( unsigned int i = 1; i < VDimension - 1; i++ )
       {
       iso += outSpacing[i];
       }
@@ -125,10 +130,10 @@ GenerateData( void )
     iso /= 2;
     for( unsigned int i = 0; i < VDimension; i++ )
       {
-      outSpacing[i] = iso.GetSum();
+      outSpacing[i] = iso;
       }
     }
-  if( m_MakeHighResIso )
+  else if( m_MakeHighResIso )
     {
     double iso = outSpacing[0];
     for( unsigned int i = 1; i < VDimension; i++ )
@@ -143,6 +148,7 @@ GenerateData( void )
       outSpacing[i] = iso;
       }
     }
+
   for( unsigned int i = 0; i < VDimension; i++ )
     {
     if( outSpacing[i] <= 0 )
@@ -153,16 +159,13 @@ GenerateData( void )
       }
     }
 
-  if( m_MatchImage )
+  std::vector< double > outResampleFactor;
+  outResampleFactor.resize( VDimension );
+  for( unsigned int i = 0; i< VDimension; i++ )
     {
-    std::vector< double > outResampleFactor;
-    outResampleFactor.resize( VDimension );
-    for( unsigned int i = 0; i< VDimension; i++ )
-      {
-      outResampleFactor[i] = inSpacing[i] / outSpacing[i];
-      outSize[i] = static_cast<unsigned long>( inSize[i]
-                                              * outResampleFactor[i] );
-      }
+    outResampleFactor[i] = inSpacing[i] / outSpacing[i];
+    outSize[i] = static_cast<unsigned long>( inSize[i]
+                                            * outResampleFactor[i] );
     }
 
   typedef typename itk::ResampleImageFilter< ImageType, ImageType >
@@ -215,7 +218,7 @@ GenerateData( void )
 
   filter->Update();
 
-  outputImage = filter->GetOutput();
+  this->GraftOutput( filter->GetOutput() );
 }
 
 template< class TPixel, unsigned int VDimension >
@@ -265,6 +268,57 @@ ResampleImageFilter< TPixel, VDimension >::
 PrintSelf( std::ostream & os, Indent indent ) const
 {
   Superclass::PrintSelf( os, indent );
+
+  os << indent << "Match Image = " << m_MatchImage << std::endl;
+  os << indent << "Spacing size = " << m_Spacing.size() << std::endl;
+  if( m_Spacing.size() > 0 )
+    {
+    os << indent << "Spacing[0] = " << m_Spacing[0] << std::endl;
+    }
+  os << indent << "Origin size = " << m_Origin.size() << std::endl;
+  if( m_Origin.size() > 0 )
+    {
+    os << indent << "Origin[0] = " << m_Origin[0] << std::endl;
+    }
+  os << indent << "Index size = " << m_Index.size() << std::endl;
+  if( m_Index.size() > 0 )
+    {
+    os << indent << "Index[0] = " << m_Index[0] << std::endl;
+    }
+  os << indent << "ResampleFactor size = " << m_ResampleFactor.size()
+    << std::endl;
+  if( m_ResampleFactor.size() > 0 )
+    {
+    os << indent << "ResampleFactor[0] = " << m_ResampleFactor[0]
+      << std::endl;
+    }
+  if( m_MakeIsotropic )
+    {
+    os << indent << "MakeIsotropic = True" << std::endl;
+    }
+  else
+    {
+    os << indent << "MakeIsotropic = False" << std::endl;
+    }
+  if( m_MakeHighResIso )
+    {
+    os << indent << "MakeHighResIso = True" << std::endl;
+    }
+  else
+    {
+    os << indent << "MakeHighResIso = False" << std::endl;
+    }
+  os << indent << "Interpolator = " << m_Interpolator << std::endl;
+  if( m_LoadTransform )
+    {
+    os << indent << "LoadTransform = True" << std::endl;
+    }
+  else
+    {
+    os << indent << "LoadTransform = False" << std::endl;
+    }
+  os << indent << "Transform = " << m_Transform << std::endl;
+
 }
 
 } // End namespace tube

--- a/ITKModules/TubeTKITK/include/tubeComputeSegmentTubesParameters.hxx
+++ b/ITKModules/TubeTKITK/include/tubeComputeSegmentTubesParameters.hxx
@@ -92,6 +92,8 @@ ComputeSegmentTubesParameters< TPixel, VDimension >
 ::PrintSelf( std::ostream & os, itk::Indent indent ) const
 {
   Superclass::PrintSelf( os, indent );
+
+  os << indent << m_Filter << std::endl;
 }
 
 } // end namespace tube

--- a/ITKModules/TubeTKITK/include/tubeConvertSpatialGraphToImage.hxx
+++ b/ITKModules/TubeTKITK/include/tubeConvertSpatialGraphToImage.hxx
@@ -67,6 +67,7 @@ ConvertSpatialGraphToImage< TInputImage, TOutputImage >
 ::PrintSelf( std::ostream & os, itk::Indent indent ) const
 {
   Superclass::PrintSelf( os, indent );
+  os << indent << m_Filter << std::endl;
 }
 
 } // end namespace tube

--- a/ITKModules/TubeTKITK/include/tubeCropImage.hxx
+++ b/ITKModules/TubeTKITK/include/tubeCropImage.hxx
@@ -129,7 +129,9 @@ void
 CropImage< TInputImage, TOutputImage >
 ::PrintSelf(std::ostream & os, itk::Indent indent) const
 {
-  m_CropFilter->PrintSelf( os, indent);
+  Superclass::PrintSelf( os, indent );
+
+  os << indent << m_CropFilter << std::endl;
 }
 
 } // end namespace tube

--- a/ITKModules/TubeTKITK/include/tubeCropTubes.hxx
+++ b/ITKModules/TubeTKITK/include/tubeCropTubes.hxx
@@ -36,6 +36,8 @@ CropTubes< VDimension >
 ::PrintSelf(std::ostream & os, itk::Indent indent) const
 {
   Superclass::PrintSelf( os, indent );
+
+  os << indent << m_Filter << std::endl;
 }
 
 } // end namespace tube

--- a/ITKModules/TubeTKITK/include/tubeEnhanceContrastUsingPrior.hxx
+++ b/ITKModules/TubeTKITK/include/tubeEnhanceContrastUsingPrior.hxx
@@ -35,7 +35,10 @@ EnhanceContrastUsingPrior< TPixel, VDimension >
 ::PrintSelf( std::ostream & os, itk::Indent indent ) const
 {
   Superclass::PrintSelf( os, indent );
+
+  os << indent << m_Filter << std::endl;
 }
+
 
 } // end namespace tube
 

--- a/ITKModules/TubeTKITK/include/tubeResampleImage.h
+++ b/ITKModules/TubeTKITK/include/tubeResampleImage.h
@@ -104,6 +104,7 @@ public:
 protected:
   ResampleImage( void );
   ~ResampleImage() {}
+
   void PrintSelf( std::ostream & os, itk::Indent indent ) const;
 
 private:

--- a/ITKModules/TubeTKITK/include/tubeResampleImage.hxx
+++ b/ITKModules/TubeTKITK/include/tubeResampleImage.hxx
@@ -75,6 +75,8 @@ ResampleImage< TPixel, VDimension >
 ::PrintSelf( std::ostream & os, itk::Indent indent ) const
 {
   Superclass::PrintSelf( os, indent );
+
+  os << indent << m_Filter << std::endl;
 }
 
 } // end namespace tube

--- a/ITKModules/TubeTKITK/include/tubeSegmentTubesUsingMinimalPath.hxx
+++ b/ITKModules/TubeTKITK/include/tubeSegmentTubesUsingMinimalPath.hxx
@@ -44,6 +44,7 @@ SegmentTubesUsingMinimalPath< Dimension, TInputPixel >
 ::PrintSelf( std::ostream & os, itk::Indent indent ) const
 {
   Superclass::PrintSelf( os, indent );
+  os << indent << m_Filter << std::endl;
 }
 
 }


### PR DESCRIPTION
ResampleImageFilter must call GraftOutput() on itk filter used in its Update function.

Wrapped filters should have complete PrintSelf functions.