### PR TITLE
ENH: Improve filenames generated when splitting using CropImage

### DIFF
--- a/Applications/CropImage/CropImage.cxx
+++ b/Applications/CropImage/CropImage.cxx
@@ -306,7 +306,7 @@ int DoIt( int argc, char * argv[] )
       out << "_";
       for( unsigned int i = 0; i < VDimension; i++ )
         {
-        out << roiIndex[i];
+        out << std::setfill('0') << std::setw(3) << roiIndex[i];
         }
       out << ".mha";
       writer->SetFileName( out.str() );


### PR DESCRIPTION
Use 0-padded numbering for filename sequences generated when an image is split into multiple regions.

This 0-padding follows the format:
<basename>-ZZZZYYYYXXXX.mha

Where ZZZZ is the Z-th split in the Z dimension, specified using 0 padding to 4 characters.   So, if you split a 100 slice file into 20 files along the z-dimension, the file names will be:
<basename>-000000000000.mha
<basename>-000100000000.mha
<basename>-000200000000.mha
....
<basename>-001900000000.mha

