### PR TITLE
BUG: Missing msg_rest function in git commit hook

### DIFF
--- a/Utilities/GitSetup/hooks/commit-msg
+++ b/Utilities/GitSetup/hooks/commit-msg
@@ -84,6 +84,10 @@ msg_second() {
 	fi
 }
 
+msg_rest() {
+:
+}
+
 # Pipe commit message into the state machine.
 state=first
 cat "$commit_msg" |


### PR DESCRIPTION
commit-msg script may have been copied from a different project and simplified.
The function "msg_rest" is missing which leads to a message being printed
in the terminal when a git commit is done. This commit adds an empty function
that could be improved if necessary.