### PR TITLE
WIP: ITKModule binary include directory only included if ENABLE_SHARED

### DIFF
--- a/ITKModules/CMakeLists.txt
+++ b/ITKModules/CMakeLists.txt
@@ -229,9 +229,13 @@ foreach( itk-module ${TubeTK_ITK_MODULES} )
 
   get_target_property( _imported ${itk-module} IMPORTED )
   if( NOT _imported )
+    set( ${itk-module}_INC_DIRS ${${itk-module}_SOURCE_DIR}/include )
+    if( ${itk-module}_ENABLE_SHARED )
+      list( APPEND
+        ${itk-module}_INC_DIRS ${${itk-module}_BINARY_DIR}/include )
+    endif()
     target_include_directories( ${itk-module} ${_target_type}
-      ${${itk-module}_SOURCE_DIR}/include
-      ${${itk-module}_BINARY_DIR}/include )
+      ${${itk-module}_INC_DIRS})
   endif()
 
 endforeach()


### PR DESCRIPTION
If an ITK module is built with ENABLE_SHARED, a file is created in the module
binary include directory. Otherwise, the module binary include directory
does not exist and should not be added to the list of include directories
of the module.