### PR TITLE
ENH: Update ITK to install module target files in subdirectory

### DIFF
--- a/CMake/Superbuild/ExternalProjectsConfig.cmake
+++ b/CMake/Superbuild/ExternalProjectsConfig.cmake
@@ -102,7 +102,7 @@ set( CTK_HASH_OR_TAG d1ebb429c952a329615f5fa9223a5897c6cc459c )
 
 # Insight Segmentation and Registration Toolkit
 set( ITK_URL ${github_protocol}://github.com/InsightSoftwareConsortium/ITK.git )
-set( ITK_HASH_OR_TAG 862bea78dbac34bf002c3a7331eec90ae240cdd5 )
+set( ITK_HASH_OR_TAG d125b69c44ac0ed7d61df0252a6b3b054c60df83 )
 
 # Slicer Execution Model
 set( SlicerExecutionModel_URL


### PR DESCRIPTION
This commit should have been part of commit d8e6470206d9a574b1069ee6569c235c3d89da00 [1]
but ITK patch 68d0b9021c003d809929615adcdc171cbaec4f2e [2] had not been merged in ITK yet.

[1] https://github.com/KitwareMedical/TubeTK/commit/d8e6470206d9a574b1069ee6569c235c3d89da00
[2] https://github.com/InsightSoftwareConsortium/ITK/commit/68d0b9021c003d809929615adcdc171cbaec4f2e