### PR TITLE
COMP: Improved handling of SetInput hidding, fix warnings, bump ITK

### DIFF
--- a/Applications/ComputeImageStatistics/ComputeImageStatistics.cxx
+++ b/Applications/ComputeImageStatistics/ComputeImageStatistics.cxx
@@ -58,7 +58,6 @@ int DoIt( int argc, char * argv[] )
   progressReporter.Start();
 
   typedef itk::Image< TPixel, VDimension >         MaskType;
-  typedef itk::Image< unsigned int, VDimension >   ConnCompType;
   typedef itk::Image< float, VDimension >          VolumeType;
   typedef itk::ImageFileReader< VolumeType >       VolumeReaderType;
   typedef itk::ImageFileReader< MaskType >         MaskReaderType;

--- a/Base/Filtering/itktubeConvertImagesToCSVFilter.h
+++ b/Base/Filtering/itktubeConvertImagesToCSVFilter.h
@@ -87,7 +87,6 @@ public:
   itkGetMacro( NumberRows, unsigned int );
 
   /** Set the input image and reinitialize the list of images */
-  using Superclass::SetInput;
   void SetInput( const InputImageType * img );
   void SetInput( unsigned int id, const InputImageType * img );
   void AddImage( const InputImageType * img );
@@ -104,6 +103,9 @@ protected:
 private:
   ConvertImagesToCSVFilter ( const Self& );
   void operator=( const Self& );
+
+  // To remove warning "was hidden [-Woverloaded-virtual]"
+  void SetInput( const DataObjectIdentifierType &, itk::DataObject * ) {};
 
   typename InputMaskType::Pointer                       m_InputMask;
   VnlMatrixType                                         m_VnlOutput;

--- a/Base/Filtering/itktubeConvertShrunkenSeedImageToListFilter.h
+++ b/Base/Filtering/itktubeConvertShrunkenSeedImageToListFilter.h
@@ -93,7 +93,6 @@ public:
   itkSetMacro( Threshold, double );
 
 protected:
-  using Superclass::SetInput;
   ConvertShrunkenSeedImageToListFilter( void );
   ~ConvertShrunkenSeedImageToListFilter( void ) {};
   virtual void GenerateData() ITK_OVERRIDE;
@@ -104,6 +103,9 @@ private:
   /** itkConvertShrunkenSeedImageToListFilter parameters **/
   ConvertShrunkenSeedImageToListFilter( const Self & );
   void operator=( const Self & );
+
+  // To remove warning "was hidden [-Woverloaded-virtual]"
+  void SetInput( const DataObjectIdentifierType &, itk::DataObject * ) {};
 
   VnlMatrixType                        m_VnlOutput;
   double                               m_Threshold;

--- a/Base/Filtering/itktubeExtractTubePointsSpatialObjectFilter.h
+++ b/Base/Filtering/itktubeExtractTubePointsSpatialObjectFilter.h
@@ -81,7 +81,6 @@ public:
   itkNewMacro( Self );
 
   /** Set/Get the input GroupSpatialObject. */
-  using Superclass::SetInput;
   virtual void SetInput( const GroupSpatialObjectType * group );
   const GroupSpatialObjectType * GetInput( void ) const;
 
@@ -108,6 +107,9 @@ private:
 
   // purposely not implemented
   void operator=( const Self & );
+
+  // To remove warning "was hidden [-Woverloaded-virtual]"
+  void SetInput( const DataObjectIdentifierType &, itk::DataObject * ) {};
 
   typename PointsContainerDecoratorType::Pointer m_PointsContainerDecorator;
   typename PointsContainerType::Pointer          m_PointsContainer;

--- a/Base/Numerics/itktubeVectorImageToListGenerator.h
+++ b/Base/Numerics/itktubeVectorImageToListGenerator.h
@@ -136,7 +136,6 @@ public:
     }
 
   /** Method to set/get the image */
-  using Superclass::SetInput;
   void SetInput( const ImageType* image );
   const ImageType* GetInput( void ) const;
 
@@ -177,6 +176,9 @@ protected:
 private:
   VectorImageToListGenerator( const Self& ); //purposely not implemented
   void operator=( const Self& ); //purposely not implemented
+
+  // To remove warning "was hidden [-Woverloaded-virtual]"
+  void SetInput( const DataObjectIdentifierType &, itk::DataObject * ) {};
 
   MaskPixelType       m_MaskValue;
   bool                m_UseSingleMaskValue;

--- a/Base/ObjectDocuments/itktubeObjectDocumentToObjectSource.h
+++ b/Base/ObjectDocuments/itktubeObjectDocumentToObjectSource.h
@@ -87,7 +87,6 @@ public:
   virtual void SetApplyTransforms( int start, int end );
 
   /** Set the input. */
-  using Superclass::SetInput;
   virtual void SetInput( const DocumentType * input );
 
   /* Graft the specified data object onto the specified indexed output, but note
@@ -169,6 +168,9 @@ private:
 
   // Copy assignment operator not implemented.
   void operator=( const Self & self );
+
+  // To remove warning "was hidden [-Woverloaded-virtual]"
+  void SetInput( const DataObjectIdentifierType &, itk::DataObject * ) {};
 
   ConstDocumentPointer  m_Input;
   int                   m_StartTransforms;

--- a/Base/Segmentation/itktubeRidgeSeedFilter.h
+++ b/Base/Segmentation/itktubeRidgeSeedFilter.h
@@ -100,7 +100,6 @@ public:
   typedef typename  PDFSegmenterType::ProbabilityImageType
     ProbabilityImageType;
 
-  using Superclass::SetInput;
   virtual void SetInput( const InputImageType * img );
   virtual void SetInput( unsigned int id, const InputImageType * img );
 
@@ -191,6 +190,9 @@ private:
 
   RidgeSeedFilter( const Self & );    // Purposely not implemented
   void operator = ( const Self & );      // Purposely not implemented
+
+  // To remove warning "was hidden [-Woverloaded-virtual]"
+  void SetInput( const DataObjectIdentifierType &, itk::DataObject * ) {};
 
   typename RidgeFeatureGeneratorType::Pointer     m_RidgeFeatureGenerator;
   typename SeedFeatureGeneratorType::Pointer      m_SeedFeatureGenerator;

--- a/Base/USTK/itkUltrasoundProbeGeometryCalculator.h
+++ b/Base/USTK/itkUltrasoundProbeGeometryCalculator.h
@@ -87,7 +87,6 @@ public:
   itkSetMacro( BackgroundValue, InputPixelType );
   itkGetConstMacro( BackgroundValue, InputPixelType );
 
-  using Superclass::SetInput;
   virtual void SetInput( const InputImageType * image );
   virtual const InputImageType * GetInput( void ) const;
 
@@ -108,6 +107,9 @@ protected:
 private:
   UltrasoundProbeGeometryCalculator( const Self & ); // purposely not implemented
   void operator=( const Self & ); // purposely not implemented
+
+  // To remove warning "was hidden [-Woverloaded-virtual]"
+  void SetInput( const DataObjectIdentifierType &, itk::DataObject * ) {};
 
   unsigned int   m_GeneralBeamDirection;
   InputPixelType m_BackgroundValue;

--- a/Base/USTK/itktubeMarkDuplicateFramesInvalidImageFilter.h
+++ b/Base/USTK/itktubeMarkDuplicateFramesInvalidImageFilter.h
@@ -134,7 +134,6 @@ public:
   itkSetMacro( FractionalThreshold, double );
   itkGetConstMacro( FractionalThreshold, double );
 
-  using Superclass::SetInput;
   virtual void SetInput( const InputImageType * image );
   virtual const InputImageType * GetInput( void ) const;
 
@@ -157,6 +156,9 @@ protected:
 private:
   MarkDuplicateFramesInvalidImageFilter( const Self & );
   void operator=( const Self & ); // purposely not implemented
+
+  // To remove warning "was hidden [-Woverloaded-virtual]"
+  void SetInput( const DataObjectIdentifierType &, itk::DataObject * ) {};
 
   InputImagePixelType m_Tolerance;
   double m_FractionalThreshold;

--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -146,7 +146,7 @@ set( CTEST_CUSTOM_WARNING_EXCEPTION
   "LIBSVM.*vsprintf"
   "LIBSVM.*min.*redefinition"
   "LIBSVM.*max.*redefinition"
-  "LIBSVM.*previous declaration is here"
+  "LIBSVM.*declaration is here"
 
   # cppcheck
   "[Cc]ppcheck.[Ll]ib"
@@ -161,6 +161,9 @@ set( CTEST_CUSTOM_WARNING_EXCEPTION
   "KWStyle.kwsStyle.cxx.*not used"
   "KWStyle.[Tt]esting"
   "detail.dynamic.sequence.hpp.*xpr.*shadows"
+
+  # numpy - used when TubeTK is wrapped
+  "Using deprecated NumPy API"
 
   # SlicerExecutionModel
   "GenerateCLP.cxx.*unused"
@@ -204,6 +207,7 @@ set( CTEST_CUSTOM_WARNING_EXCEPTION
   "[Mm]odules.[Ff]iltering.[Ff]ast[Mm]arching"
   "[Mm]odules.[Rr]emote.[Mm]inimal[Pp]ath[Ee]xtraction"
   "[Mm]odules.*unary minus operator applied to unsigned"
+  "libpcre.*has no symbols"
 
   # VTK suppressions
   "vtkfreetype"

--- a/CMake/Superbuild/ExternalProjectsConfig.cmake
+++ b/CMake/Superbuild/ExternalProjectsConfig.cmake
@@ -71,20 +71,14 @@ set( TubeTK_ITK_MODULES
   MinimalPathExtraction
   )
 
-###########################################################
-###########################################################
-# The following were copied from Slicer on 12/03/2016
-###########################################################
-###########################################################
-
 # Insight Segmentation and Registration Toolkit
 set( ITK_URL ${github_protocol}://github.com/InsightSoftwareConsortium/ITK.git )
-set( ITK_HASH_OR_TAG d125b69c44ac0ed7d61df0252a6b3b054c60df83 )
+set( ITK_HASH_OR_TAG eda099680acca5b590a5f13e96bdebb9718a27a6 )
 
 # Slicer Execution Model
 set( SlicerExecutionModel_URL
   ${github_protocol}://github.com/Slicer/SlicerExecutionModel.git )
-set( SlicerExecutionModel_HASH_OR_TAG 62d0121dbb0fb057ebbd7c9ab84520accacec8bc )
+set( SlicerExecutionModel_HASH_OR_TAG de0ee402097df9c4a092b789547757a7fd970a7c )
 
 # Visualization Toolkit (3D Slicer fork)
 set( VTK_URL ${github_protocol}://github.com/Slicer/VTK.git )

--- a/ITKModules/TubeTKITK/include/tubeConvertImagesToCSV.h
+++ b/ITKModules/TubeTKITK/include/tubeConvertImagesToCSV.h
@@ -86,6 +86,9 @@ private:
   ConvertImagesToCSV( const Self & );
   void operator=( const Self & );
 
+  // To remove warning "was hidden [-Woverloaded-virtual]"
+  void SetInput( const DataObjectIdentifierType &, itk::DataObject * ) {};
+
   typename ConvertImagesToCSVFilterType::Pointer m_ConvertImagesToCSVFilter;
 
 };

--- a/ITKModules/TubeTKITK/include/tubeConvertShrunkenSeedImageToList.h
+++ b/ITKModules/TubeTKITK/include/tubeConvertShrunkenSeedImageToList.h
@@ -80,7 +80,6 @@ public:
   tubeWrapCallMacro( Update, ConvertShrunkenSeedImageToListFilter );
 
 protected:
-  using Superclass::SetInput;
   ConvertShrunkenSeedImageToList( void );
   ~ConvertShrunkenSeedImageToList() {}
   void PrintSelf( std::ostream & os, itk::Indent indent ) const;
@@ -89,6 +88,9 @@ private:
   /** itkConvertShrunkenSeedImageToListFilter parameters **/
   ConvertShrunkenSeedImageToList( const Self & );
   void operator=( const Self & );
+
+  // To remove warning "was hidden [-Woverloaded-virtual]"
+  void SetInput( const DataObjectIdentifierType &, itk::DataObject * ) {};
 
   typename ConvertShrunkenSeedImageToListFilterType::Pointer
     m_ConvertShrunkenSeedImageToListFilter;


### PR DESCRIPTION
Was exposing un-supported SetInput methods, and now they are masked
by private void implementations instead.

Fixed unused typedefs.

Masked numpy deprecated and LIBSVM deprecated warnings from dashboard

Bumped ITK version