### PR TITLE
BUG: Add paths associated with MinimalPathExtraction module

### DIFF
--- a/Applications/SegmentTubeUsingMinimalPath/CMakeLists.txt
+++ b/Applications/SegmentTubeUsingMinimalPath/CMakeLists.txt
@@ -40,6 +40,8 @@ include( ${ITK_USE_FILE} )
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/Base/CLI/TubeTKLogo.h
+  INCLUDE_DIRECTORIES
+    ${MinimalPathExtraction_INCLUDE_DIRS}
   TARGET_LIBRARIES
     ${ITK_LIBRARIES} ITKIOMeta ITKIOSpatialObjects ITKIOImageBase
     MinimalPathExtraction TubeCLI TubeTKCommon TubeTKSegmentation


### PR DESCRIPTION
When an ITK module is used, it might have been built as a remote module.

Include directories of remote modules are given in a module-specific cmake file
that is included when ITK is included in a project, but the paths
for that module are not included when ITK include paths are included.
The paths of a remote module must be specifically included by applications
that use them.