### PR TITLE
COMP: Supress warnings from MacOS10.12: OSAtomic/OSMemory deprecated API

### DIFF
--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -175,7 +175,7 @@ set( CTEST_CUSTOM_WARNING_EXCEPTION
   "Slicer.CMake.SlicerMacroConfigureGenericCxxModuleTests.*(if)"
 
   # STL - Tiger
-  "include.c.*bits.stl_algo.h.*warning: comparison between signed and unsigned integer expressions"
+  "include.c.*bits.stl_algo.h.*warning: comparison between signed"
 
   # Make
   "warning: jobserver unavailable"
@@ -208,6 +208,9 @@ set( CTEST_CUSTOM_WARNING_EXCEPTION
   "[Mm]odules.[Rr]emote.[Mm]inimal[Pp]ath[Ee]xtraction"
   "[Mm]odules.*unary minus operator applied to unsigned"
   "libpcre.*has no symbols"
+  # MacOS 10.12 deprecations
+  "OSMemory.*deprecated"
+  "OSAtomic.*deprecated"
 
   # VTK suppressions
   "vtkfreetype"


### PR DESCRIPTION
Addressed the warnings:

Slicer-Release/ITKv4/Modules/Core/Common/include/itkAtomicIntDetail.h:137:12: warning: 'OSAtomicAdd64Barrier' is deprecated: first deprecated in macOS 10.12 - Use std::atomic_fetch_add() from  instead [-Wdeprecated-declarations]

Slicer-Release/ITKv4/Modules/Core/Common/include/itkAtomicIntDetail.h:259:5: warning: 'OSMemoryBarrier' is deprecated: first deprecated in macOS 10.12 - Use std::atomic_thread_fence() from  instead [-Wdeprecated-declarations]