### PR TITLE
COMP: Set path to MinimalPathExtraction-build/include

### DIFF
--- a/Applications/SegmentTubeUsingMinimalPath/CMakeLists.txt
+++ b/Applications/SegmentTubeUsingMinimalPath/CMakeLists.txt
@@ -42,6 +42,7 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/Base/CLI/TubeTKLogo.h
   INCLUDE_DIRECTORIES
     "${MinimalPathExtraction_INCLUDE_DIRS}"
+    "${MinimalPathExtraction_BINARY_DIR}/include"
   TARGET_LIBRARIES
     ${ITK_LIBRARIES} ITKIOMeta ITKIOSpatialObjects ITKIOImageBase
     MinimalPathExtraction TubeCLI TubeTKCommon TubeTKSegmentation


### PR DESCRIPTION
If MinimalPathExtraction is built using ITK in Slicer, then
the path to the MinimalPathExtractionExport.h file needs to be
explicitely set when it is built at the same time an application
that uses it is built.