### PR TITLE
US CNN Vessel seg - Generalize old code and consolidate preprocessing, training, and testing

### DIFF
--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/ConvertData.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/ConvertData.py
@@ -20,119 +20,169 @@ import json
 script_params = json.load(open('params.json'))
 caffe_root = script_params['CAFFE_SRC_ROOT']
 hardDrive_root = script_params['CNN_DATA_ROOT']
+proj_rel_path = script_params['PROJECT_REL_PATH']
+
+caffe_proj_root = os.path.join(caffe_root, "data", proj_rel_path)
+hardDrive_proj_root = os.path.join(hardDrive_root, proj_rel_path)
+
 
 # Shrink images
-def shrink( inputImage, expertImage, outputImagePrefix ):
-  subprocess.call( ["ShrinkImage", "-n 512,512,10",
-                    "-o 0,0,20",
-                    "-p", outputImagePrefix + "_points.mha",
-                    inputImage,
-                    outputImagePrefix + ".mha"] )
-  subprocess.call( ["ShrinkImage", "-n 512,512,10",
-                    expertImage,
-                    outputImagePrefix + "_expert.mha"] )
+def shrink(inputImage, expertImage, outputImagePrefix):
+
+    subprocess.call(["ShrinkImage", "-n 512,512,10",
+                     "-o 0,0,20",
+                     "-p", outputImagePrefix + "_zslab_points.mha",
+                     inputImage,
+                     outputImagePrefix + "_zslab.mha"])
+    subprocess.call(["ShrinkImage", "-n 512,512,10",
+                     expertImage,
+                     outputImagePrefix + "_zslab_expert.mha"])
+
+    subprocess.call(["ImageMath",
+                     "-w", outputImagePrefix + ".mha",
+                     inputImage])
+
 
 # Convert TRE file to Image
-def convert( templateFile, tubeFile, outputFile ):
-  subprocess.call( ["ConvertTubesToImage", "-r",
-                    templateFile,
-                    tubeFile,
-                    outputFile ] )
+def convertTubesToImage(templateFile, tubeFile, outputFile):
 
-# Copy infile to outFile
-def copy( inFile, outFile ):
+    subprocess.call(["ConvertTubesToImage", "-r",
+                     templateFile,
+                     tubeFile,
+                     outputFile])
 
-  # create path if it doesnt exist
-  out_path = os.path.dirname( outFile )
-  if not os.path.exists( out_path ):
-    os.makedirs( out_path )
 
-  # copy file
-  shutil.copyfile(inFile, outFile)
+# Copy infile to outFile and create dirs if not present
+def copy(inFile, outFile):
+
+    # create path if it doesnt exist
+    out_path = os.path.dirname(outFile)
+    if not os.path.exists(out_path):
+        os.makedirs(out_path)
+
+    # copy file
+    shutil.copyfile(inFile, outFile)
 
 
 def main(argv):
 
-  # Input data directories
-  controls = os.path.join(caffe_root, "data/SegmentVesselsUsingNeuralNetworks/Controls/*")
-  tumors = os.path.join(caffe_root, "data/SegmentVesselsUsingNeuralNetworks/LargeTumor/*")
+    # Input data directories
+    controls = os.path.join(caffe_proj_root, "Controls/*")
+    tumors = os.path.join(caffe_proj_root, "LargeTumor/*")
 
-  # Output data directories
-  expertDir = os.path.join(caffe_root, "data/SegmentVesselsUsingNeuralNetworks/expert/")
-  controlsOutputDir = os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/controls/")
-  tumorsOutputDir = os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/tumors/")
+    # Output data directories
+    expertDir = os.path.join(caffe_proj_root, "expert")
+    controlsOutputDir = os.path.join(hardDrive_proj_root, "controls")
+    tumorsOutputDir = os.path.join(hardDrive_proj_root, "tumors")
 
-  # Sanity checks
-  if not os.path.exists( os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/") ):
-    os.mkdir( os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/") )
+    # Sanity checks
+    if not os.path.exists(hardDrive_proj_root):
+        os.mkdir(hardDrive_proj_root)
 
-  if not os.path.exists( expertDir ):
-    os.mkdir( expertDir )
+    if not os.path.exists(expertDir):
+        os.mkdir(expertDir)
 
-  if not os.path.exists( controlsOutputDir ):
-    os.mkdir( controlsOutputDir )
+    if not os.path.exists(controlsOutputDir):
+        os.mkdir(controlsOutputDir)
 
-  if not os.path.exists( tumorsOutputDir ):
-    os.mkdir( tumorsOutputDir )
+    if not os.path.exists(tumorsOutputDir):
+        os.mkdir(tumorsOutputDir)
 
-  # Files to process
-  controlFiles = glob.glob( os.path.join( controls, "*.mhd" ) )
-  tumorFiles = glob.glob( os.path.join( tumors, "*.mhd" ) )
+    # Files to process
+    controlMhdFiles = glob.glob(os.path.join(controls, "*.mhd"))
+    tumorMhdFiles = glob.glob(os.path.join(tumors, "*.mhd"))
 
-  # Output directories where to copy the data for training and testing
-  i=0
+    # Output directories where to copy the data for training and testing
+    trainOutputDir = os.path.join(hardDrive_proj_root, "training")
+    testOutputDir = os.path.join(hardDrive_proj_root, "testing")
 
-  trainOutputDir = os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/training/")
-  testOutputDir = os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/testing/")
+    # Process control files
+    i = 0
 
-  # Process control files
-  for file in controlFiles:
-      # Create filenames
-      filePrefix = os.path.basename(os.path.splitext(file)[0])
-      fileDirectory = os.path.dirname(os.path.abspath(file))
-      templateFile = file
-      tubeFile = os.path.join(fileDirectory, "TRE", filePrefix + ".tre")
-      expertFile = os.path.join(expertDir, filePrefix + "_expert.mha")
+    for mhdFile in controlMhdFiles:
 
-      # Process
-      convert( templateFile, tubeFile, expertFile )
-      shrink( templateFile, expertFile, os.path.join(controlsOutputDir, filePrefix) )
+        # Create filenames
+        filePrefix = os.path.basename(os.path.splitext(mhdFile)[0])
+        fileDir = os.path.dirname(os.path.abspath(mhdFile))
 
-      # Mixing controls for testing and training.
-      if i%2 == 0 :
-        copy( os.path.join(controlsOutputDir, filePrefix + ".mha"), os.path.join(trainOutputDir, "images", filePrefix + ".mha") )
-        copy( os.path.join(controlsOutputDir, filePrefix + "_points.mha"), os.path.join(trainOutputDir, "points", filePrefix + "_points.mha") )
-        copy( os.path.join(controlsOutputDir, filePrefix + "_expert.mha"), os.path.join(trainOutputDir, "expert", filePrefix + "_expert.mha") )
-      else :
-        copy( os.path.join(controlsOutputDir, filePrefix + ".mha"), os.path.join(testOutputDir, "images", filePrefix + ".mha") )
-        copy( os.path.join(controlsOutputDir, filePrefix + "_points.mha"), os.path.join(testOutputDir, "points", filePrefix + "_points.mha") )
-        copy( os.path.join(controlsOutputDir, filePrefix + "_expert.mha"), os.path.join(testOutputDir, "expert", filePrefix + "_expert.mha") )
-      i = i+1
+        print("control file %d/%d : " %
+              (i + 1, len(controlMhdFiles)), filePrefix)
 
-  i=0
-  # Process tumor files
-  for file in tumorFiles:
-      # Create filenames
-      filePrefix = os.path.basename(os.path.splitext(file)[0])
-      fileDirectory = os.path.dirname(os.path.abspath(file))
-      templateFile = file
-      tubeFile = os.path.join(fileDirectory, "TRE", filePrefix + ".tre")
-      expertFile = os.path.join(expertDir, filePrefix + "_expert.mha")
+        treFile = os.path.join(fileDir, "TRE", filePrefix + ".tre")
+        expertFile = os.path.join(
+            controlsOutputDir, filePrefix + "_expert.mha")
 
-      # Process
-      convert( templateFile, tubeFile, expertFile )
-      shrink( templateFile, expertFile, tumorsOutputDir + filePrefix )
+        # Process
+        convertTubesToImage(mhdFile, treFile, expertFile)
+        shrink(mhdFile, expertFile,
+               os.path.join(controlsOutputDir, filePrefix))
 
-      # Mixing tumors for testing and training.
-      if i%2 == 0 :
-        copy( os.path.join(tumorsOutputDir, filePrefix + ".mha"), os.path.join(trainOutputDir, "images", filePrefix + ".mha") )
-        copy( os.path.join(tumorsOutputDir, filePrefix + "_points.mha"), os.path.join(trainOutputDir, "points", filePrefix + "_points.mha") )
-        copy( os.path.join(tumorsOutputDir, filePrefix + "_expert.mha"), os.path.join(trainOutputDir, "expert", filePrefix + "_expert.mha") )
-      else :
-        copy( os.path.join(tumorsOutputDir, filePrefix + ".mha"), os.path.join(testOutputDir, "images", filePrefix + ".mha") )
-        copy( os.path.join(tumorsOutputDir, filePrefix + "_points.mha"), os.path.join(testOutputDir, "points", filePrefix + "_points.mha") )
-        copy( os.path.join(tumorsOutputDir, filePrefix + "_expert.mha"), os.path.join(testOutputDir, "expert",  filePrefix + "_expert.mha") )
-      i = i+1
+        # Mixing controls for testing and training.
+        if i % 2 == 0:
+            curOutputDir = trainOutputDir
+        else:
+            curOutputDir = testOutputDir
+
+        copy(os.path.join(controlsOutputDir, filePrefix + ".mha"),
+             os.path.join(curOutputDir, "images", filePrefix + ".mha"))
+
+        copy(os.path.join(controlsOutputDir, filePrefix + "_zslab.mha"),
+             os.path.join(curOutputDir, "images", filePrefix + "_zslab.mha"))
+
+        copy(os.path.join(controlsOutputDir, filePrefix + "_zslab_points.mha"),
+             os.path.join(curOutputDir, "points", filePrefix + "_zslab_points.mha"))
+
+        copy(os.path.join(controlsOutputDir, filePrefix + "_expert.mha"),
+             os.path.join(curOutputDir, "expert", filePrefix + "_expert.mha"))
+
+        copy(os.path.join(controlsOutputDir, filePrefix + "_zslab_expert.mha"),
+             os.path.join(curOutputDir, "expert", filePrefix + "_zslab_expert.mha"))
+
+        i += 1
+
+    # Process tumor files
+    i = 0
+
+    for mhdFile in tumorMhdFiles:
+
+        # Create filenames
+        filePrefix = os.path.basename(os.path.splitext(mhdFile)[0])
+        fileDir = os.path.dirname(os.path.abspath(mhdFile))
+
+        print("tumor file %d / %d : " %
+              (i + 1, len(tumorMhdFiles)), filePrefix)
+
+        treFile = os.path.join(fileDir, "TRE", filePrefix + ".tre")
+        expertFile = os.path.join(
+            tumorsOutputDir, filePrefix + "_expert.mha")
+
+        # Process
+        convertTubesToImage(mhdFile, treFile, expertFile)
+        shrink(mhdFile, expertFile,
+               os.path.join(tumorsOutputDir, filePrefix))
+
+        # Mixing controls for testing and training.
+        if i % 2 == 0:
+            curOutputDir = trainOutputDir
+        else:
+            curOutputDir = testOutputDir
+
+        copy(os.path.join(tumorsOutputDir, filePrefix + ".mha"),
+             os.path.join(curOutputDir, "images", filePrefix + ".mha"))
+
+        copy(os.path.join(tumorsOutputDir, filePrefix + "_zslab.mha"),
+             os.path.join(curOutputDir, "images", filePrefix + "_zslab.mha"))
+
+        copy(os.path.join(tumorsOutputDir, filePrefix + "_zslab_points.mha"),
+             os.path.join(curOutputDir, "points", filePrefix + "_zslab_points.mha"))
+
+        copy(os.path.join(tumorsOutputDir, filePrefix + "_expert.mha"),
+             os.path.join(curOutputDir, "expert", filePrefix + "_expert.mha"))
+
+        copy(os.path.join(tumorsOutputDir, filePrefix + "_zslab_expert.mha"),
+             os.path.join(curOutputDir, "expert", filePrefix + "_zslab_expert.mha"))
+
+        i += 1
 
 if __name__ == "__main__":
-  main( sys.argv[0:] )
+    main(sys.argv[0:])

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/ExtractVessels.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/ExtractVessels.py
@@ -11,51 +11,60 @@
 #
 ###########################################################################
 
-import sys
+import json
 import os
 import subprocess
 
-def computeSeeds( inputImage, outputImage ):
-  subprocess.call( ["ImageMath", inputImage,
-                    "-t", "0", "8", "0", "1",
-                    "-W","0", outputImage] )
 
-def segmentTubes( inputImage, outputTRE, seedImage, scaleImage, vascularModel ):
-  subprocess.call( ["SegmentTubes",
+def computeSeeds( inputImage, outputImage ):
+    subprocess.call(["ImageMath", inputImage,
+                     "-t", "0", "8", "0", "1",
+                     "-W", "0", outputImage])
+
+
+def segmentTubes(inputImage, outputTRE, seedImage, scaleImage, vascularModel):
+
+    subprocess.call(["SegmentTubes",
                     #"-o", tmpDir + "/out_VesselMask.mha",
                     "-P", vascularModel,
                     "-M", seedImage,
                     "-s", "0.1",       #Scale constant
                     #"-S", scaleImage, # or scale image
                     inputImage,
-                    outputTRE ] )
-  # Fill gaps
-  subprocess.call( ["ConvertTubesToTubeTree",
+                    outputTRE])
+    # Fill gaps
+    subprocess.call(["ConvertTubesToTubeTree",
                      "--maxTubeDistanceToRadiusRatio", "3",
                      "--removeOrphanTubes",
                     outputTRE,
-                    outputTRE + "Tree.tre"] )
-  subprocess.call( ["TreeMath",
+                    outputTRE + "Tree.tre"])
+    subprocess.call(["TreeMath",
                     "-f", "S",
                     outputTRE + "Tree.tre",
-                    "-w", outputTRE + "Tree.tre"] )
+                    "-w", outputTRE + "Tree.tre"])
 
 ########
 # Main #
 ########
-# Path variable
-caffe_root = "./"
-hardDrive_root = "/media/lucas/krs0014/"
 
-extractionDir = caffe_root + "data/SegmentVesselsUsingNeuralNetworks/Extraction/"
+# Set path variables
+script_params = json.load(open('params.json'))
+caffe_root = script_params['CAFFE_SRC_ROOT']
+hardDrive_root = script_params['CNN_DATA_ROOT']
+
+proj_name = "SegmentVesselsUsingNeuralNetworks"
+caffe_vseg_root = os.path.join(caffe_root, "data", proj_name)
+hardDrive_vseg_root = os.path.join(hardDrive_root, proj_name)
+
+extractionDir = os.path.join(caffe_vseg_root, "Extraction")
 
 # Images path
-seedImage = hardDrive_root + "SegmentVesselsUsingNeuralNetworks/output/3d.mha"
-inputImage = caffe_root + "data/SegmentVesselsUsingNeuralNetworks/Controls/A34/pp07_A34_left.mhd"
-outputTRE = extractionDir + "out.tre"
-scaleImage = extractionDir + "input_ExpertEnhancedScales.mha"
-vascularModel = extractionDir + "vascularModel.mtp"
+seedImage = os.path.join(hardDrive_vseg_root, "output/3d.mha")
+inputImage = os.path.join(caffe_vseg_root, "Controls/A36/pp07_A36_left.mhd")
+outputTRE = os.path.join(extractionDir, "out.tre")
+scaleImage = os.path.join(extractionDir, "input_ExpertEnhancedScales.mha")
+vascularModel = os.path.join(extractionDir, "vascularModel.mtp")
 
 # Process extraction
-computeSeeds( seedImage, extractionDir + "seed.mha" )
-segmentTubes( inputImage, outputTRE, extractionDir+"seed.mha", scaleImage, vascularModel )
+computeSeeds(seedImage, os.path.join(extractionDir, "seed.mha"))
+segmentTubes(inputImage, outputTRE, os.path.join(extractionDir, "seed.mha"), scaleImage, vascularModel)

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PreProcessing.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PreProcessing.py
@@ -11,144 +11,179 @@
 #
 ###########################################################################
 
-import os, glob, sys, json
+import os
+import glob
+import json
 
 import matplotlib.image as mpimg
 import matplotlib.pyplot as plt
 
-import numpy as np
+import random
+import math
 
-import random, math
 
 # Create image set and save expected output
-def createImgSet( expertImg, inputImg, filenamePrefix, fileOutputDir,
-  textFilename ):
-  w = 32; #Patch size
-  count = 0; #Input count
-  negativeImageIndex = [] #Whole image index giving negative output
-  negativeIndex = [] #Vessel bound index giving negative output
+def createImgSet(expertImg, inputImg, filenamePrefix, fileOutputDir, textFile):
 
-  # Write filename and expected output
-  textFile = open(textFilename, "a")
-  textFile.truncate() # Erase file
+    w = 32  # Patch size
+    count = 0  # Input count
+    negativeImageIndex = []  # Whole image index giving negative output
+    negativeIndex = []  # Vessel bound index giving negative output
 
-  resample = 1;#WARNING: resample pixels to reduce training size for Debug
+    # Write filename and expected output
+    textFile = open(textFile, "a")
+    textFile.truncate()  # Erase file
 
-  # Iterate through the expert label map
-  for i in range(0,expertImg.shape[0],resample):
-    for j in range(0,expertImg.shape[1],resample):
+    resample = 1  # WARNING: resample pixels to reduce training size for Debug
 
-      if j>w and j+w+1<inputImg.shape[1] :
-        if i>w and i+w+1<inputImg.shape[0]:
+    # Iterate through the expert label map
+    for i in range(0, expertImg.shape[0], resample):
+        for j in range(0, expertImg.shape[1], resample):
 
-	      # Centerline pixel (positive)
-              if expertImg[i,j] > 0.5:
-                count = count + 1
-                filename = filenamePrefix + "_" + str(i) + "_" + str(j) +".png"
-                textFile.write(filename + " " + str(1) + "\n")
-                plt.imsave(os.path.join(fileOutputDir, filename),
-                           inputImg[i-w:i+w+1,j-w:j+w+1],cmap='Greys_r')
+            if j > w and j + w + 1 < inputImg.shape[1]:
+                if i > w and i + w + 1 < inputImg.shape[0]:
 
-              # Vessel bound pixel (negative)
-              elif expertImg[i,j] > 0:
-                negativeIndex.append([i,j])
+                    # Centerline pixel (positive)
+                    if expertImg[i, j] > 0.5:
+                        count += 1
+                        filename = os.path.join(
+                            "1", filenamePrefix + "_" + str(i) + "_" + str(j) + ".png")
+                        textFile.write(filename + " " + str(1) + "\n")
+                        plt.imsave(os.path.join(fileOutputDir, filename),
+                                   inputImg[i - w:i + w + 1, j - w:j + w + 1], cmap='Greys_r')
 
-              # Background pixel (negative)
-              else :
-                negativeImageIndex.append([i,j])
+                    # Vessel bound pixel (negative)
+                    elif expertImg[i, j] > 0:
+                        negativeIndex.append([i, j])
 
-  # Pick random negatives from vessel bound
-  rndmNegativeInd = random.sample(negativeIndex, int(math.ceil(0.8*count)))
-  for [i,j] in rndmNegativeInd :
-    filename = filenamePrefix + "_" + str(i) + "_" + str(j) + ".png"
-    textFile.write(filename + " " + str(0) + "\n")
-    plt.imsave(os.path.join(fileOutputDir, filename),
-               inputImg[i-w:i+w+1,j-w:j+w+1],cmap='Greys_r')
+                    # Background pixel (negative)
+                    else:
+                        negativeImageIndex.append([i, j])
 
-  # Pick random negatives from the entire image
-  rndmNegativeImageInd = random.sample(negativeImageIndex, int(math.ceil(0.2*count)))
-  for [i,j] in rndmNegativeImageInd :
-    filename = filenamePrefix + "_" + str(i) + "_" + str(j) + ".png"
-    textFile.write(filename + " " + str(0) + "\n")
-    plt.imsave(os.path.join(fileOutputDir, filename),
-               inputImg[i-w:i+w+1,j-w:j+w+1],cmap='Greys_r')
+    # Pick random negatives from vessel bound
+    rndmNegativeInd = random.sample(negativeIndex, int(math.ceil(0.8 * count)))
+    for [i, j] in rndmNegativeInd:
+        filename = os.path.join("0", filenamePrefix +
+                                "_" + str(i) + "_" + str(j) + ".png")
+        textFile.write(filename + " " + str(0) + "\n")
+        plt.imsave(os.path.join(fileOutputDir, filename),
+                   inputImg[i - w:i + w + 1, j - w:j + w + 1], cmap='Greys_r')
 
-  textFile.close()
-  print count
+    # Pick random negatives from the entire image
+    rndmNegativeImageInd = random.sample(
+        negativeImageIndex, int(math.ceil(0.2 * count)))
+    for [i, j] in rndmNegativeImageInd:
+        filename = os.path.join("0", filenamePrefix +
+                                "_" + str(i) + "_" + str(j) + ".png")
+        textFile.write(filename + " " + str(0) + "\n")
+        plt.imsave(os.path.join(fileOutputDir, filename),
+                   inputImg[i - w:i + w + 1, j - w:j + w + 1], cmap='Greys_r')
+
+    textFile.close()
+    print(count)
 
 ########
 # Main #
 ########
+
 # Path variable
 script_params = json.load(open('params.json'))
 caffe_root = script_params['CAFFE_SRC_ROOT']
 hardDrive_root = script_params['CNN_DATA_ROOT']
+proj_rel_path = script_params['PROJECT_REL_PATH']
+
+caffe_proj_root = os.path.join(caffe_root, "data", proj_rel_path)
+hardDrive_proj_root = os.path.join(hardDrive_root, proj_rel_path)
+
+trainDataDir = os.path.join(hardDrive_proj_root, "training")
+valDataDir = os.path.join(hardDrive_proj_root, "testing")
 
 # Text file
-trainFilename = os.path.join(caffe_root, "data/SegmentVesselsUsingNeuralNetworks/train.txt")
+trainFilename = os.path.join(caffe_proj_root, "train.txt")
 trainFile = open(trainFilename, "w+")
-trainFile.truncate() # Erase file
+trainFile.truncate()  # Erase file
 trainFile.close()
 
-valFilename = os.path.join(caffe_root, "data/SegmentVesselsUsingNeuralNetworks/val.txt")
+valFilename = os.path.join(caffe_proj_root, "val.txt")
 valFile = open(valFilename, "w+")
-valFile.truncate() # Erase file
+valFile.truncate()  # Erase file
 valFile.close()
 
 # Output patches directories
-trainFileOutputDir= os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/training/out/")
+trainFileOutputDir = os.path.join(trainDataDir, "out")
 if not os.path.exists(trainFileOutputDir):
-  os.mkdir(trainFileOutputDir)
+    os.mkdir(trainFileOutputDir)
 
-valFileOutputDir = os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/testing/out/")
+for label in range(2):
+    curLabelOutputDir = os.path.join(trainFileOutputDir, str(label))
+    if not os.path.exists(curLabelOutputDir):
+        os.mkdir(curLabelOutputDir)
+
+valFileOutputDir = os.path.join(valDataDir, "out")
 if not os.path.exists(valFileOutputDir):
-  os.mkdir(valFileOutputDir)
+    os.mkdir(valFileOutputDir)
+
+for label in range(2):
+    curLabelOutputDir = os.path.join(valFileOutputDir, str(label))
+    if not os.path.exists(curLabelOutputDir):
+        os.mkdir(curLabelOutputDir)
 
 # Images directories
-trainExpertDir = os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/training/expert/")
-trainImgDir = os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/training/images/")
+trainExpertDir = os.path.join(trainDataDir, "expert")
+trainImgDir = os.path.join(trainDataDir, "images")
 
-valExpertDir = os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/testing/expert/")
-valImgDir = os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/testing/images/")
+valExpertDir = os.path.join(valDataDir, "expert")
+valImgDir = os.path.join(valDataDir, "images")
 
 # Create train set
-trainImages = glob.glob( os.path.join( trainImgDir, "*.png" ) )
+trainImages = glob.glob(os.path.join(trainImgDir, "*.png"))
+
 for trainImage in trainImages:
-  print trainImage
-  # Get image ID
-  trainImagePrefix = os.path.basename(os.path.splitext(trainImage)[0])
-  # Set filename
-  trainExpertFilename = os.path.join(trainExpertDir, trainImagePrefix + "_expert.png")
-  trainImgFilename = os.path.join(trainImgDir, trainImagePrefix + ".png")
-  # Load images
-  trainExpert=mpimg.imread(trainExpertFilename)
-  #print trainExpert.shape
-  #trainExpert=trainExpert[:,:,0]
-  trainImg=mpimg.imread(trainImgFilename)
-  #trainImg=trainImg[:,:,0]
 
-  # Write images and text files
-  createImgSet( trainExpert, trainImg, trainImagePrefix, trainFileOutputDir, trainFilename )
+    print(trainImage)
 
-#Create validation set
-valImages = glob.glob( os.path.join( valImgDir, "*.png" ) )
+    # Get image ID
+    trainImagePrefix = os.path.basename(os.path.splitext(trainImage)[0])
+
+    # Set filename
+    trainExpertFile = os.path.join(
+        trainExpertDir, trainImagePrefix + "_expert.png")
+    trainImageFile = os.path.join(trainImgDir, trainImagePrefix + ".png")
+
+    # Load images
+    trainExpert = mpimg.imread(trainExpertFile)
+
+    # print trainExpert.shape
+    # trainExpert=trainExpert[:,:,0]
+
+    trainImg = mpimg.imread(trainImageFile)
+    # trainImg=trainImg[:,:,0]
+
+    # Write images and text files
+    createImgSet(trainExpert, trainImg, trainImagePrefix,
+                 trainFileOutputDir, trainFilename)
+
+# Create validation set
+valImages = glob.glob(os.path.join(valImgDir, "*.png"))
 for valImage in valImages:
 
-  print valImage
+    print(valImage)
 
-  # Get image ID
-  valImagePrefix = os.path.basename(os.path.splitext(valImage)[0])
+    # Get image ID
+    valImagePrefix = os.path.basename(os.path.splitext(valImage)[0])
 
-  # Set filename
-  valExpertFilename = os.path.join(valExpertDir, valImagePrefix + "_expert.png")
-  valImgFilename = os.path.join(valImgDir, valImagePrefix + ".png")
+    # Set filename
+    valExpertFilename = os.path.join(
+        valExpertDir, valImagePrefix + "_expert.png")
+    valImgFilename = os.path.join(valImgDir, valImagePrefix + ".png")
 
-  # Load images
-  valExpert=mpimg.imread(valExpertFilename)
+    # Load images
+    valExpert = mpimg.imread(valExpertFilename)
 
-  #valExpert=valExpert[:,:,0]
-  valImg=mpimg.imread(valImgFilename)
-  #valImg=valImg[:,:,0]
+    # valExpert=valExpert[:,:,0]
+    valImg = mpimg.imread(valImgFilename)
+    # valImg=valImg[:,:,0]
 
-  # Write images and text files
-  createImgSet( valExpert, valImg, valImagePrefix, valFileOutputDir, valFilename )
+    # Write images and text files
+    createImgSet(valExpert, valImg, valImagePrefix,
+                 valFileOutputDir, valFilename)

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
@@ -1,0 +1,552 @@
+#!/usr/bin/python
+
+###########################################################################
+# PrepareTrainingData.py :
+#
+# Prepares training data for CNN
+#
+###########################################################################
+
+import glob
+import json
+import math
+import os
+import random
+import subprocess
+import shutil
+import sys
+
+import skimage.io
+
+import utils
+
+# Append ITK libs
+sys.path.append(os.path.join(os.environ['TubeTK_BUILD_DIR'], 'ITK-build',
+                             'Wrapping/Generators/Python'))
+sys.path.append(os.path.join(os.environ['TubeTK_BUILD_DIR'], 'ITK-build',
+                             'Modules/ThirdParty/VNL/src/vxl/lib'))
+import itk
+
+# Define paths
+script_params = json.load(open('params.json'))
+
+caffe_root = script_params['CAFFE_SRC_ROOT']
+hardDrive_root = script_params['CNN_DATA_ROOT']
+proj_rel_path = script_params['PROJECT_REL_PATH']
+
+caffe_proj_root = os.path.join(caffe_root, "data", proj_rel_path)
+hardDrive_proj_root = os.path.join(hardDrive_root, proj_rel_path)
+
+
+# Create segmentation mask from tre file
+def createExpertSegmentationMask(inputImageFile, treFile, outputExpertSegFile):
+
+    # convert tre file to image
+    subprocess.call(["ConvertTubesToImage", "-r",
+                     inputImageFile,
+                     treFile,
+                     outputExpertSegFile])
+
+
+# Shrink images
+def shrink(inputImage, expertImage, outputImagePrefix):
+
+    shrinked_size = "-n 512,512,%d" % script_params["NUM_SLABS"]
+    window_overlap = "-o 0,0,%d" % script_params["SLAB_OVERLAP"]
+
+    subprocess.call(["ShrinkImage", shrinked_size, window_overlap,
+                     "-p", outputImagePrefix + "_zslab_points.mha",
+                     inputImage,
+                     outputImagePrefix + "_zslab.mha"])
+
+    subprocess.call(["ShrinkImage", shrinked_size, window_overlap,
+                     "-i", outputImagePrefix + "_zslab_points.mha",
+                     expertImage,
+                     outputImagePrefix + "_zslab_expert.mha"])
+
+    """
+    subprocess.call(["ShrinkImage", shrinked_size,
+                     expertImage,
+                     outputImagePrefix + "_zslab_expert.mha"])
+    """
+
+    # save a copy of inputImage in .mha format
+    subprocess.call(["ImageMath",
+                     "-w", outputImagePrefix + ".mha",
+                     inputImage])
+
+
+# create z-mip slabs
+def createZMIPSlabs():
+
+    # Input data directories where mha/mhd and associated tre files are located
+    controlInputDir = os.path.join(caffe_proj_root, "Controls")
+    tumorInputDir = os.path.join(caffe_proj_root, "LargeTumor")
+
+    # Output data directories
+    controlOutputDir = os.path.join(hardDrive_proj_root, "controls")
+    tumorOutputDir = os.path.join(hardDrive_proj_root, "tumors")
+
+    # Sanity checks
+    if not os.path.exists(controlOutputDir):
+        os.makedirs(controlOutputDir)
+
+    if not os.path.exists(tumorOutputDir):
+        os.makedirs(tumorOutputDir)
+
+    # Process control files
+    printSectionHeader('Creating Z-MIP slabs for controls')
+
+    controlMhdFiles = glob.glob(os.path.join(controlInputDir, "*", "*.mhd"))
+
+    i = 0
+
+    for mhdFile in controlMhdFiles:
+
+        print("\ncontrol file %d/%d : %s" %
+              (i + 1, len(controlMhdFiles), mhdFile))
+
+        fileName = os.path.basename(os.path.splitext(mhdFile)[0])
+        fileDir = os.path.dirname(os.path.abspath(mhdFile))
+
+        treFile = os.path.join(fileDir, "TRE", fileName + ".tre")
+        expertSegFile = os.path.join(controlOutputDir,
+                                     fileName + "_expert.mha")
+
+        # Process
+        createExpertSegmentationMask(mhdFile, treFile, expertSegFile)
+
+        shrink(mhdFile, expertSegFile,
+               os.path.join(controlOutputDir, fileName))
+
+        i += 1
+
+    # Process tumor files
+    printSectionHeader('Creating Z-MIP slabs for tumors')
+
+    tumorMhdFiles = glob.glob(os.path.join(tumorInputDir, "*", "*.mhd"))
+
+    i = 0
+
+    for mhdFile in tumorMhdFiles:
+
+        print("\ntumor file %d/%d : %s" %
+              (i + 1, len(tumorMhdFiles), mhdFile))
+
+        fileName = os.path.basename(os.path.splitext(mhdFile)[0])
+        fileDir = os.path.dirname(os.path.abspath(mhdFile))
+
+        treFile = os.path.join(fileDir, "TRE", fileName + ".tre")
+        expertSegFile = os.path.join(tumorOutputDir,
+                                     fileName + "_expert.mha")
+
+        # Process
+        createExpertSegmentationMask(mhdFile, treFile, expertSegFile)
+
+        shrink(mhdFile, expertSegFile,
+               os.path.join(tumorOutputDir, fileName))
+
+        i += 1
+
+
+# Compute Training mask
+def computeTrainingMask(expertSegMask, outputTrainingMask):
+
+    subprocess.call(["SegmentBinaryImageSkeleton",
+                     expertSegMask,
+                     expertSegMask + "_skel.png"])
+
+    subprocess.call([
+        "ImageMath", expertSegMask,
+         # dilate vessel mask with kernel radius = 1
+         "-M", "1", "1", "255", "0",
+        # subtract vessel mask from dilated version to get vessel boundary
+        "-a", "1", "-1", expertSegMask,
+        # create training mask with vessel center-line (=255) and boundary (=128)
+        "-a", "0.5", "255", expertSegMask + "_skel.png",
+        # write training mask
+        "-W", "0", outputTrainingMask])
+
+    subprocess.call(["rm", "-rf", expertSegMask + "_skel.png"])
+
+    # WARNING: Couldn't write to PNG using the implemented CLI
+    # subprocess.call( ["ComputeTrainingMask",
+    # expertSegMask,
+    # outputTrainingMask,
+    # "--notVesselWidth","1"] )
+
+
+# save each of the z-mip slabs from .mha files as a .png file
+def saveSlabs(mhaFileList):
+
+    PixelType = itk.F
+    Dimension = 3
+    ImageType = itk.Image[PixelType, Dimension]
+    ReaderType = itk.ImageFileReader[ImageType]
+
+    for mhaFile in mhaFileList:
+
+        print 'saving slabs of %s' % mhaFile
+
+        reader = ReaderType.New()
+        reader.SetFileName(str(mhaFile))
+        reader.Update()
+        img = reader.GetOutput()
+        buf = itk.PyBuffer[ImageType].GetArrayFromImage(img)
+
+        # convert to [0, 255] range
+        buf = 255.0 * (buf - buf.min()) / (buf.max() - buf.min())
+        buf = buf.astype('uint8')
+
+        # file names definition
+        fileName = os.path.basename(os.path.splitext(mhaFile)[0])
+        fileDir = os.path.dirname(os.path.abspath(mhaFile))
+
+        # Iterate through each slab
+        for i in range(buf.shape[0]):
+
+            outputImage = os.path.join(
+                fileDir, str(i) + "_" + fileName + ".png")
+
+            skimage.io.imsave(outputImage, buf[i, :, :])
+
+
+# assign control and tumor volumes equally to training and testing
+def splitControlTumorData():
+
+    # Input data directories
+    controlInputDir = os.path.join(caffe_proj_root, "Controls")
+    tumorInputDir = os.path.join(caffe_proj_root, "LargeTumor")
+
+    # Output data directories
+    controlOutputDir = os.path.join(hardDrive_proj_root, "controls")
+    tumorOutputDir = os.path.join(hardDrive_proj_root, "tumors")
+
+    trainOutputDir = os.path.join(hardDrive_proj_root, "training")
+    testOutputDir = os.path.join(hardDrive_proj_root, "testing")
+
+    # Sanity checks
+    if not os.path.exists(trainOutputDir):
+        os.makedirs(trainOutputDir)
+
+    if not os.path.exists(testOutputDir):
+        os.makedirs(testOutputDir)
+
+    # Process control files
+    printSectionHeader('Splitting control data into training and testing')
+
+    controlMhdFiles = glob.glob(os.path.join(controlInputDir, "*", "*.mhd"))
+
+    i = 0
+
+    for mhdFile in controlMhdFiles:
+
+        print("\ncontrol file %d/%d : %s" %
+              (i + 1, len(controlMhdFiles), mhdFile))
+
+        filePrefix = os.path.basename(os.path.splitext(mhdFile)[0])
+
+        # Split equally for training and testing
+        if i % 2 == 0:
+            curOutputDir = trainOutputDir
+        else:
+            curOutputDir = testOutputDir
+
+        # copy input volume
+        utils.copy(os.path.join(controlOutputDir, filePrefix + ".mha"),
+                   os.path.join(curOutputDir, "images", filePrefix + ".mha"))
+
+        # copy z-mip slab volume
+        utils.copy(os.path.join(controlOutputDir, filePrefix + "_zslab.mha"),
+                   os.path.join(curOutputDir, "images", filePrefix + "_zslab.mha"))
+
+        # copy z-mip slab point map
+        utils.copy(os.path.join(controlOutputDir, filePrefix + "_zslab_points.mha"),
+                   os.path.join(curOutputDir, "points", filePrefix + "_zslab_points.mha"))
+
+        # copy expert volume
+        utils.copy(os.path.join(controlOutputDir, filePrefix + "_expert.mha"),
+                   os.path.join(curOutputDir, "expert", filePrefix + "_expert.mha"))
+
+        # copy expert z-mip slab volume
+        utils.copy(os.path.join(controlOutputDir, filePrefix + "_zslab_expert.mha"),
+                   os.path.join(curOutputDir, "expert", filePrefix + "_zslab_expert.mha"))
+
+        # save slabs as pngs
+        saveSlabs([
+            os.path.join(curOutputDir, "images", filePrefix + "_zslab.mha"),
+            os.path.join(curOutputDir, "expert",
+                         filePrefix + "_zslab_expert.mha")
+        ])
+
+        i += 1
+
+    # Process tumor files
+    printSectionHeader('Splitting tumor data into training and testing')
+
+    tumorMhdFiles = glob.glob(os.path.join(tumorInputDir, "*", "*.mhd"))
+
+    i = 0
+
+    for mhdFile in tumorMhdFiles:
+
+        print("\ntumor file %d / %d : %s" %
+              (i + 1, len(tumorMhdFiles), mhdFile))
+
+        filePrefix = os.path.basename(os.path.splitext(mhdFile)[0])
+
+        # Split equally for training and testing
+        if i % 2 == 0:
+            curOutputDir = trainOutputDir
+        else:
+            curOutputDir = testOutputDir
+
+        # copy input volume
+        utils.copy(os.path.join(tumorOutputDir, filePrefix + ".mha"),
+                   os.path.join(curOutputDir, "images", filePrefix + ".mha"))
+
+        # copy z-mip slab volume
+        utils.copy(os.path.join(tumorOutputDir, filePrefix + "_zslab.mha"),
+                   os.path.join(curOutputDir, "images", filePrefix + "_zslab.mha"))
+
+        # copy z-mip slab point map
+        utils.copy(os.path.join(tumorOutputDir, filePrefix + "_zslab_points.mha"),
+                   os.path.join(curOutputDir, "points", filePrefix + "_zslab_points.mha"))
+
+        # copy expert volume
+        utils.copy(os.path.join(tumorOutputDir, filePrefix + "_expert.mha"),
+                   os.path.join(curOutputDir, "expert", filePrefix + "_expert.mha"))
+
+        # copy expert z-mip slab volume
+        utils.copy(os.path.join(tumorOutputDir, filePrefix + "_zslab_expert.mha"),
+                   os.path.join(curOutputDir, "expert", filePrefix + "_zslab_expert.mha"))
+
+        # save slabs as pngs
+        saveSlabs([
+            os.path.join(curOutputDir, "images", filePrefix + "_zslab.mha"),
+            os.path.join(curOutputDir, "expert",
+                         filePrefix + "_zslab_expert.mha")
+        ])
+
+        i += 1
+
+
+# Extracts +ve (vessel center) and -ve (background) patches from image
+def extractPatchesFromImage(rootDir, imageName, outputDir, patchListFile):
+
+    # patch/window radius
+    w = script_params['PATCH_RADIUS']
+
+    # fraction of negatives near vessel boundary
+    vessel_bnd_neg_frac = script_params['NEGATIVES_NEAR_VESSEL_BOUNDARY']
+
+    # read input image
+    inputImageFile = os.path.join(rootDir, "images", imageName + '.png')
+    inputImage = skimage.io.imread(inputImageFile)
+
+    # read expert segmented label mask
+    expertSegFile = os.path.join(rootDir, "expert", imageName + '_expert.png')
+    trainingMaskFile = os.path.join(rootDir, "expert", imageName + '_train.png')
+
+    computeTrainingMask(expertSegFile, trainingMaskFile)
+
+    trainingMask = skimage.io.imread(trainingMaskFile)
+
+    # Iterate through expert mask and find pos/neg patches
+    numVesselPatches = 0
+
+    vesselBndInd = []  # Indices of background pixels near vessel boundary
+    bgndInd = []  # Indices of all other background pixels
+    subsample = 1  # Increase to reduce time for debugging
+
+    for i in range(w, trainingMask.shape[0] - w - 1, subsample):
+        for j in range(w, trainingMask.shape[1] - w - 1, subsample):
+
+            # Vessel center-line pixel (positive)
+            if trainingMask[i, j] > 0.6 * 255:
+
+                filename = os.path.join(
+                    "1", imageName + "_" + str(i) + "_" + str(j) + ".png")
+
+                patchListFile.write(filename + " " + str(1) + "\n")
+
+                skimage.io.imsave(os.path.join(outputDir, filename),
+                                  inputImage[i - w : i + w + 1, j - w : j + w + 1])
+
+                numVesselPatches += 1
+
+            # Vessel bound pixel (negative)
+            elif trainingMask[i, j] > 0:
+
+                vesselBndInd.append([i, j])
+
+            # Background pixel (negative)
+            else:
+
+                bgndInd.append([i, j])
+
+    # Pick a subset of background (negative) patches near vessel boundary
+    numVesselBndPatches = int(
+        math.ceil(vessel_bnd_neg_frac * numVesselPatches))
+
+    selVesselBndInd = random.sample(vesselBndInd, numVesselBndPatches)
+
+    for [i, j] in selVesselBndInd:
+
+        filename = os.path.join("0", imageName +
+                                "_" + str(i) + "_" + str(j) + ".png")
+
+        patchListFile.write(filename + " " + str(0) + "\n")
+
+        skimage.io.imsave(os.path.join(outputDir, filename),
+                          inputImage[i - w : i + w + 1, j - w : j + w + 1])
+
+    # Pick rest of background (negative) patches away from vessel boundary
+    numOtherBgndPatches = \
+        int(math.ceil((1.0 - vessel_bnd_neg_frac) * numVesselPatches))
+
+    selBgndInd = random.sample(bgndInd, numOtherBgndPatches)
+
+    for [i, j] in selBgndInd:
+
+        filename = os.path.join("0", imageName +
+                                "_" + str(i) + "_" + str(j) + ".png")
+
+        patchListFile.write(filename + " " + str(0) + "\n")
+
+        skimage.io.imsave(os.path.join(outputDir, filename),
+                          inputImage[i - w : i + w + 1, j - w : j + w + 1])
+
+    print 'Number of positive patches = ', numVesselPatches
+
+
+# convert train/test images to patches
+def createTrainTestPatches():
+
+    # create training patches
+    printSectionHeader('Creating training patches')
+
+    trainDataDir = os.path.join(hardDrive_proj_root, "training")
+    trainImageFiles = glob.glob(os.path.join(trainDataDir, "images", "*.png"))
+
+    trainPatchesDir = os.path.join(trainDataDir, "patches")
+    for i in range(2):
+        if not os.path.exists(os.path.join(trainPatchesDir, str(i))):
+            os.makedirs(os.path.join(trainPatchesDir, str(i)))
+
+    trainPatchListFile = open(os.path.join(trainPatchesDir, "train.txt"), "w")
+    trainPatchListFile.truncate()
+
+    i = 0
+
+    for imageFile in trainImageFiles:
+
+        print('\nCreating patches for train file %d/%d - %s' %
+              (i + 1, len(trainImageFiles), imageFile))
+
+        imageName = os.path.basename(os.path.splitext(imageFile)[0])
+
+        extractPatchesFromImage(trainDataDir, imageName, trainPatchesDir,
+                                trainPatchListFile)
+
+        i += 1
+
+    trainPatchListFile.close()
+
+    # create testing patches
+    printSectionHeader('Creating testing patches')
+
+    testDataDir = os.path.join(hardDrive_proj_root, "testing")
+    testImageFiles = glob.glob(os.path.join(testDataDir, "images", "*.png"))
+
+    testPatchesDir = os.path.join(testDataDir, "patches")
+    for i in range(2):
+        if not os.path.exists(os.path.join(testPatchesDir, str(i))):
+            os.makedirs(os.path.join(testPatchesDir, str(i)))
+
+    testPatchListFile = open(os.path.join(testPatchesDir, "val.txt"), "w+")
+    testPatchListFile.truncate()  # Erase file
+
+    i = 0
+    for imageFile in testImageFiles:
+
+        print('\nCreating patches for test file %d/%d - %s' %
+              (i + 1, len(testImageFiles), imageFile))
+
+        imageName = os.path.basename(os.path.splitext(imageFile)[0])
+
+        extractPatchesFromImage(testDataDir, imageName, testPatchesDir,
+                                testPatchListFile)
+
+        i += 1
+
+    testPatchListFile.close()
+
+
+# create lmdb
+def createTrainTestLmdb():
+
+    printSectionHeader('Creating LMDBs for train and test data')
+
+    caffe_tools_dir = os.path.join(caffe_root, "build", "tools")
+    convert_imageset_exec = os.path.join(caffe_tools_dir, "convert_imageset")
+
+    # create training lmdb
+    print('Creating training lmdb ...\n')
+
+    train_patches_dir = os.path.join(
+        hardDrive_proj_root, "training", "patches/")
+
+    train_lmdb_dir = os.path.join(caffe_proj_root, "Net_TrainData")
+    if os.path.exists(train_lmdb_dir):
+        shutil.rmtree(train_lmdb_dir)
+
+    subprocess.call([convert_imageset_exec,
+                     "--shuffle",
+                     "--gray",
+                     train_patches_dir,
+                     os.path.join(train_patches_dir, "train.txt"),
+                     train_lmdb_dir])
+
+    # create testing lmdb
+    print('Creating testing lmdb ...\n')
+
+    test_patches_dir = os.path.join(hardDrive_proj_root, "testing", "patches/")
+
+    test_lmdb_dir = os.path.join(caffe_proj_root, "Net_ValData")
+    if os.path.exists(test_lmdb_dir):
+        shutil.rmtree(test_lmdb_dir)
+
+    subprocess.call([convert_imageset_exec,
+                     "--shuffle",
+                     "--gray",
+                     test_patches_dir,
+                     os.path.join(test_patches_dir, "val.txt"),
+                     test_lmdb_dir])
+
+
+def printSectionHeader(title):
+
+    print("\n" + "#" * (len(title) + 4))
+    print('# ' + title)
+    print("#" * (len(title) + 4) + "\n")
+
+
+def run():
+
+    # create z-mip slabs
+    createZMIPSlabs()
+
+    # assign control and tumor volumes equally to training and testing
+    # Note: this must be called after createZMIPSlabs()
+    splitControlTumorData()
+
+    # convert train/test images to patches
+    createTrainTestPatches()
+
+    # create lmdb database
+    createTrainTestLmdb()
+
+
+if __name__ == "__main__":
+    run()

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/ProcessNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/ProcessNet.py
@@ -5,92 +5,109 @@
 ###########################################################################
 
 from __future__ import division
-import os, sys
 
+import os, sys, json
 import matplotlib.pyplot as plt
 import matplotlib.image as mpimg
 import numpy as np
 from pylab import *
 
-sys.path.insert(0, caffe_root + 'python') #Append pycaffe to sys.path
+# Define paths
+script_params = json.load(open('params.json'))
+caffe_root = str(script_params['CAFFE_SRC_ROOT'])
+hardDrive_root = str(script_params['CNN_DATA_ROOT'])
+
+proj_name = "SegmentVesselsUsingNeuralNetworks"
+caffe_proj_root = os.path.join(caffe_root, "data", proj_name)
+hardDrive_proj_root = os.path.join(hardDrive_root, proj_name)
+
+# import caffe
+sys.path.insert(0, os.path.join(caffe_root, 'python'))  # Append pycaffe to sys.path
 
 import caffe
 from caffe import layers as L, params as P
 
-# Path variable
-caffe_root = "./"  # this file should be run from {caffe_root} (otherwise change this line)
+# Process one input image
+def segmentImage(net, inputFilename, outputFilename):
 
-## Process one input image
-def segmentImage( net, inputFilename, outputFilename ):
-  img=mpimg.imread( inputFilename )
-  # WARNING : Useful Debug plot and print to check data pixel value and shape
-  #img=img.astype(float)
-  #plt.imshow(img[:,:,0], cmap='gray')
-  #plt.show()
-  img=img[:,:,0]
-  #print img[250:260,250]
-  #plt.imshow(img, cmap='gray')
-  #plt.show()
+    img=mpimg.imread( inputFilename )
+    # WARNING : Useful Debug plot and print to check data pixel value and shape
+    #img=img.astype(float)
+    #plt.imshow(img[:,:,0], cmap='gray')
+    #plt.show()
+    img=img[:,:,0]
+    #print img[250:260,250]
+    #plt.imshow(img, cmap='gray')
+    #plt.show()
 
-  w = 32; # Patch size
-  index = [] # Save pixel index to reconstruct output
-  inputImg = [] # Input patches to classify
-  outputImg = np.zeros((img.shape[0],img.shape[1])) # Output segmented slab
+    w = 32;  # Patch size
+    index = []  # Save pixel index to reconstruct output
+    inputImg = []  # Input patches to classify
+    outputImg = np.zeros((img.shape[0],img.shape[1]))  # Output segmented slab
 
-  for i in range(img.shape[0]):
-      for j in range(img.shape[1]):
-	#img[i,j]/=255.0
-	  if j>w and j+w<img.shape[1] :
-	    if i>w and i+w<img.shape[0]:
-	      index.append([i,j]) #Save index
-	      inputImg.append(img[i-w:i+w+1,j-w:j+w+1]) #Save input patch
+    for i in range(img.shape[0]):
+        for j in range(img.shape[1]):
 
-  print "Number of pixels to classify : ", len(inputImg)
+          #img[i,j]/=255.0
 
-  status = 0# Status report variable
-  # Classify pixels
-  for i in range(100*512,len(inputImg)-100*512,1) : #WARNING: Reduce images size for speed
-    net.blobs['data'].data[0,0] = inputImg[i]
-    ## perform classification
-    output = net.forward()
-    #pixelScore = net.blobs['score'].data[0][1] # the output score vector for the first image in the batch
-    pixelClass = output['loss'][0][1] # the output probability vector for the first image in the batch
-    ## set output
-    outputImg[index[i][0],index[i][1]]=pixelClass
-    ## Print status
-    #print str(i)+" : ",net.blobs['score'].data[0].argmax(), pixelClass, net.blobs['score'].data[0][0],net.blobs['score'].data[0][1]
-    if i % (len(inputImg)//20) == 0:
-      print ".." + str(status) + "%"
-      status = status + 5
+          if j>w and j+w<img.shape[1] :
+              if i>w and i+w<img.shape[0]:
+                  index.append([i,j])  # Save index
+                  inputImg.append(img[i-w:i+w+1,j-w:j+w+1])  # Save input patch
 
-  # Save output
-  plt.imsave( outputFilename, outputImg, cmap='Greys_r' )
+    print("Number of pixels to classify : ", len(inputImg))
+
+    status = 0  #  Status report variable
+
+    # Classify pixels
+    for i in range(100*512,len(inputImg)-100*512,1) :  # WARNING: Reduce images size for speed
+
+        net.blobs['data'].data[0,0] = inputImg[i]
+
+        # perform classification using cnn
+        output = net.forward()
+
+        # pixelScore = net.blobs['score'].data[0][1]  # the output score vector for the first image in the batch
+        pixelClass = output['loss'][0][1] # the output probability vector for the first image in the batch
+
+        ## set output
+        outputImg[index[i][0],index[i][1]] = pixelClass
+
+        ## Print status
+        #print str(i)+" : ",net.blobs['score'].data[0].argmax(), pixelClass, net.blobs['score'].data[0][0],net.blobs['score'].data[0][1]
+        if i % (len(inputImg)//20) == 0:
+            print(".." + str(status) + "%")
+            status += 5
+
+    # Save output
+    plt.imsave(outputFilename, outputImg, cmap='Greys_r')
 
 
 ########
 # Main #
 ########
+
 # Model weights
-caffeModelWeights = caffe_root + 'data/SegmentVesselsUsingNeuralNetworks/NetProto/net_iter_10000.caffemodel'
+caffeModelWeights = os.path.join(caffe_proj_root, "NetProto/net_best.caffemodel")
 
 # Sanity check
 if os.path.isfile( caffeModelWeights ):
-  print("Caffe model weights " + caffeModelWeights + " found." )
-else :
-  print('Error : Caffe model weights "' + caffeModelWeights + '" not found.\n'+
-    '  Train neural network before processing it.')
-  sys.exit(0)
+    print("Caffe model weights " + caffeModelWeights + " found.")
+else:
+    print('Error : Caffe model weights "' + caffeModelWeights + '" not found.\n'+
+          '  Train neural network before processing it.')
+    sys.exit(0)
 
 # Model definition
-caffeModelDef = caffe_root + 'data/SegmentVesselsUsingNeuralNetworks/NetProto/deploy.prototxt'
+caffeModelDef = os.path.join(caffe_proj_root, "NetProto/deploy.prototxt")
 
 # Sanity check
 if os.path.isfile( caffeModelDef ):
-  print("Caffe model definition " + caffeModelDef + " found." )
-else :
-  print('Error : Caffe model definition "' + caffeModelDef + '" not found.\n'+
-    '  Train neural network before processing it.')
-  sys.exit(0)
+    print("Caffe model definition " + caffeModelDef + " found.")
+else:
+    print('Error : Caffe model definition "' + caffeModelDef + '" not found.\n'+
+          '  Train neural network before processing it.')
+    sys.exit(0)
 
 # Create network
 caffe.set_mode_gpu()
@@ -101,21 +118,23 @@ net = caffe.Net(caffeModelDef,      # defines the structure of the model
 
 # set the size of the input (we can skip this if we're happy
 #  with the default; we can also change it later, e.g., for different batch sizes)
-w = 32;
+w = 32
 net.blobs['data'].reshape(1,         # batch size
-                          1,         # 1-channel
+                          1,            # 1-channel
                           2*w+1, 2*w+1)  # image size
 
 # Create and segment inputs
-hardDrive_root = "/media/lucas/krs0014/"
+inputDir = os.path.join(hardDrive_proj_root, "testing/images")
+outputDir = os.path.join(hardDrive_proj_root, "output")
 
-inputDir = hardDrive_root + "SegmentVesselsUsingNeuralNetworks/testing/images/"
-outputDir = hardDrive_root + "SegmentVesselsUsingNeuralNetworks/output/"
-inputAnimal = "pp07_A34_left.png" #WARNING Hardcoded
+if not os.path.exists(outputDir):
+    os.makedirs(outputDir)
+
+inputAnimal = "pp07_A36_left.png"  # WARNING Hardcoded
 
 ## Segment all animal slabs
 for i in range(10):
-  inputFilename = inputDir + str(i) + "_" + inputAnimal
-  outputFilename = outputDir + str(i) + "_" + inputAnimal
-  print(inputFilename)
-  segmentImage( net, inputFilename, outputFilename )
+    inputFilename = os.path.join(inputDir, str(i) + "_" + inputAnimal)
+    outputFilename = os.path.join(outputDir, str(i) + "_" + inputAnimal)
+    print(inputFilename)
+    segmentImage( net, inputFilename, outputFilename )

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
@@ -1,0 +1,384 @@
+#!/usr/bin/python
+"""
+Tests the trained CNN vessel segmentation mode on all test images
+"""
+import os
+import sys
+import json
+import glob
+import subprocess
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+import skimage.io
+import skimage.filters
+
+import utils
+
+# Append ITK libs
+sys.path.append(os.path.join(
+    os.environ['TubeTK_BUILD_DIR'], 'ITK-build/Wrapping/Generators/Python'))
+sys.path.append(os.path.join(
+    os.environ['TubeTK_BUILD_DIR'], 'ITK-build/Modules/ThirdParty/VNL/src/vxl/lib'))
+import itk
+
+# Define paths
+script_params = json.load(open('params.json'))
+caffe_root = script_params['CAFFE_SRC_ROOT']
+hardDrive_root = script_params['CNN_DATA_ROOT']
+proj_rel_path = script_params['PROJECT_REL_PATH']
+
+caffe_proj_root = os.path.join(caffe_root, "data", proj_rel_path)
+hardDrive_proj_root = os.path.join(hardDrive_root, proj_rel_path)
+
+testDataDir = os.path.join(hardDrive_proj_root, "testing")
+
+# import caffe
+sys.path.insert(0, os.path.join(caffe_root, 'python'))
+import caffe
+
+
+# Segment a slab
+def segmentSlab(net, input_file, output_file):
+
+    print "Segmenting slab ", input_file
+
+    print net.blobs['data'].data.shape
+
+    # read input slab image
+    input_image = skimage.io.imread(input_file)
+
+    # get foreground mask
+    th = skimage.filters.threshold_otsu(input_image)
+    fgnd_mask = input_image > th
+
+    # get test_batch_size and patch_size used for cnn net
+    test_batch_size = net.blobs['data'].data.shape[0]
+    patch_size = net.blobs['data'].data.shape[2]
+
+    print 'Test batch shape = ', net.blobs['data'].data.shape
+
+    # collect all patches
+    print "Extracting patches ... "
+
+    start_time = time.time()
+
+    w = np.int(patch_size / 2)
+
+    patches = []
+    patch_indices = []
+
+    for i in range(w, input_image.shape[0] - w):
+        for j in range(w, input_image.shape[1] - w):
+
+            # check if pixel is in foreground
+            # if ~fgnd_mask[i, j]:
+            #    continue
+
+            # store patch center index
+            patch_indices.append([i, j])
+
+            # store patch
+            cur_patch = input_image[(i - w):(i + w + 1), (j - w):(j + w + 1)]
+            patches.append(cur_patch)
+
+    end_time = time.time()
+
+    print '\tTook %s seconds' % (end_time - start_time)
+
+    num_patches = len(patch_indices)
+    patches = np.array(patches)
+    patch_indices = np.array(patch_indices)
+
+    print "\tNo of patches = %s" % num_patches
+
+    # Classify patches using cnn and write result in output image
+    print "Classifying patches ... "
+
+    start_time = time.time()
+
+    output_image = np.zeros_like(input_image)  # Output segmented slab
+    output_image_flat = np.ravel(output_image)
+
+    pw = test_batch_size - (num_patches % test_batch_size)
+    patches = np.pad(patches, ((0, pw), (0, 0), (0, 0)), 'constant')
+    patch_indices = np.pad(patch_indices, ((0, pw), (0, 0)), 'constant')
+
+    patches = np.rollaxis(np.expand_dims(patches, 3), 3, 1)
+    print patches.shape
+
+    for i in range(0, num_patches, test_batch_size):
+
+        # get current batch of patches
+        cur_pind = patch_indices[i:i + test_batch_size]
+        cur_patches = patches[i:i + test_batch_size]
+
+        # perform classification using cnn
+        net.blobs['data'].data[...] = cur_patches
+
+        output = net.forward()
+
+        prob_vessel = output['loss'][:, 1]
+
+        if i + test_batch_size > num_patches:
+
+            # remove padded part for last batch
+            num_valid = num_patches - i
+            prob_vessel = prob_vessel[0:num_valid]
+            cur_pind = cur_pind[0:num_valid, :]
+
+        # set output
+        cur_pind_lin = np.ravel_multi_index((cur_pind[:, 0], cur_pind[:, 1]),
+                                            output_image.shape)
+
+        output_image_flat[cur_pind_lin] = prob_vessel * 255
+
+        # Print progress
+        print '\t %.2f%%' % (100.0 * (i + len(prob_vessel)) / num_patches),
+        if len(prob_vessel) > 0:
+            print "%.4f, %.4f, %.4f" % (prob_vessel.min(),
+                                        prob_vessel.max(),
+                                        prob_vessel.mean())
+        else:
+            print ""
+
+    end_time = time.time()
+    print '\tTook %s seconds' % (end_time - start_time)
+
+    # Save output
+    skimage.io.imsave(output_file, output_image)
+
+
+def combineSlabs(inputImageName, outputDir):
+
+    PixelType = itk.UC
+    Dimension = 3
+    ImageType = itk.Image[PixelType, Dimension]
+
+    NameGeneratorType = itk.NumericSeriesFileNames
+    nameGenerator = NameGeneratorType.New()
+    nameGenerator.SetStartIndex(0)
+    nameGenerator.SetEndIndex(9)
+    nameGenerator.SetIncrementIndex(1)
+    nameGenerator.SetSeriesFormat(
+        str(os.path.join(outputDir, "%d_" + inputImageName + '_zslab.png')))
+
+    SeriesReaderType = itk.ImageSeriesReader[ImageType]
+    seriesReader = SeriesReaderType.New()
+    seriesReader.SetFileNames(nameGenerator.GetFileNames())
+    #  seriesReader.SetImageIO( itk.PNGImageIO.New() )
+
+    WriterType = itk.ImageFileWriter[ImageType]
+    writer = WriterType.New()
+    writer.SetFileName(
+        str(os.path.join(outputDir, inputImageName + "_zslab.mha")))
+    writer.SetInput(seriesReader.GetOutput())
+    writer.Update()
+
+
+def reconstructSegVolume(inputImageName, outputDir):
+
+    PixelType = itk.F
+    Dimension = 3
+    ImageType = itk.Image[PixelType, Dimension]
+
+    # combine slab images into a .mha volume file
+    combineSlabs(inputImageName, outputDir)
+
+    # Read segmented slab volume
+    slabSegFile = str(os.path.join(outputDir, inputImageName + "_zslab.mha"))
+
+    SlabVolumeReaderType = itk.ImageFileReader[ImageType]
+    slabVolumeReader = SlabVolumeReaderType.New()
+    slabVolumeReader.SetFileName(slabSegFile)
+    slabVolumeReader.Update()
+    slabSeg = slabVolumeReader.GetOutput()
+    slabSegBuf = itk.PyBuffer[ImageType].GetArrayFromImage(slabSeg)
+
+    # Read point map image
+    pointMapFile = str(os.path.join(
+        testDataDir, "points", inputImageName + "_zslab_points.mha"))
+
+    VectorImageType = itk.VectorImage[PixelType, Dimension]
+    PointMapReaderType = itk.ImageFileReader[VectorImageType]
+    pointMapReader = PointMapReaderType.New()
+    pointMapReader.SetFileName(pointMapFile)
+    pointMapReader.Update()
+    pointMap = pointMapReader.GetOutput()
+    pointMapBuf = itk.PyBuffer[VectorImageType].GetArrayFromImage(pointMap)
+
+    # Read input volume
+    inputVolumeFile = str(os.path.join(os.path.join(
+        testDataDir, "images", inputImageName + ".mha")))
+
+    InputVolumeReaderType = itk.ImageFileReader[ImageType]
+    inputVolumeReader = InputVolumeReaderType.New()
+    inputVolumeReader.SetFileName(inputVolumeFile)
+    inputVolumeReader.Update()
+
+    # reconstruct segmentation volume in original space by inverse mapping
+    img3d = inputVolumeReader.GetOutput()
+
+    img3d.FillBuffer(0.0)
+
+    numSlabs = slabSegBuf.shape[0]
+
+    for slabIdx in range(numSlabs):
+
+        print "Reconstructing slab ", slabIdx + 1, "/", numSlabs, "..."
+
+        for i in range(slabSegBuf.shape[1]):
+            for j in range(slabSegBuf.shape[2]):
+
+                predProb = slabSegBuf[slabIdx, i, j] / 255.0
+
+                src_x = float(pointMapBuf[slabIdx, i, j, 0])
+                src_y = float(pointMapBuf[slabIdx, i, j, 1])
+                src_z = float(pointMapBuf[slabIdx, i, j, 2])
+                src_index = img3d.TransformPhysicalPointToIndex(
+                    [src_x, src_y, src_z])
+
+                img3d.SetPixel(src_index, predProb)
+
+    # Blur image to fill gaps between painted pixels.
+    BlurFilterType = itk.DiscreteGaussianImageFilter[ImageType, ImageType]
+    blurFilter = BlurFilterType.New()
+    blurFilter.SetInput(img3d)
+    blurFilter.SetVariance(1)
+    blurFilter.SetMaximumKernelWidth(1)
+
+    print("Writing output ..")
+    WriterType = itk.ImageFileWriter[ImageType]
+    writer = WriterType.New()
+    writer.UseCompressionOn()
+    writer.SetFileName(
+        str(os.path.join(outputDir, inputImageName + "_vess_prob.mha")))
+    writer.SetInput(blurFilter.GetOutput())
+    writer.Update()
+
+
+def segmentTubes(inputImageName, vascularModelFile, outputDir,
+                 vess_seed_prob=0.95, vess_scale=0.1):
+
+    inputImageFile = os.path.join(
+        testDataDir, "images", inputImageName + ".mha")
+
+    # compute seed image
+    vessProbImageFile = os.path.join(
+        outputDir, inputImageName + "_vess_prob.mha")
+    outSeedImageFile = os.path.join(
+        outputDir, inputImageName + "_vess_seeds.mha")
+
+    subprocess.call(["ImageMath", vessProbImageFile,
+                     "-t", str(vess_seed_prob), "1.0", "1", "0",
+                     "-W", "0", outSeedImageFile])
+
+    # segment tubes using ridge traversal
+    outVsegMaskFile = os.path.join(outputDir, inputImageName + "_vseg.mha")
+    outVsegTreFile = os.path.join(outputDir, inputImageName + "_vseg.tre")
+
+    subprocess.call(["SegmentTubes",
+                     "-o", outVsegMaskFile,
+                     "-P", vascularModelFile,
+                     "-M", outSeedImageFile,
+                     "-s", str(vess_scale),
+                     inputImageFile, outVsegTreFile])
+
+    # Fill gaps and convert to a tree
+    subprocess.call(["ConvertTubesToTubeTree",
+                     "--maxTubeDistanceToRadiusRatio", "3",
+                     "--removeOrphanTubes",
+                     outVsegTreFile,
+                     outVsegTreFile])
+
+    subprocess.call(["TreeMath",
+                     "-f", "S",
+                     "-w", outVsegTreFile,
+                     outVsegTreFile])
+
+
+def run():
+
+    # set output directory
+    outputDir = os.path.join(hardDrive_proj_root, "testing", "cnn")
+
+    if not os.path.exists(outputDir):
+        os.makedirs(outputDir)
+
+    sys.stdout = utils.Logger(os.path.join(outputDir, 'net_test.log'))
+
+    # Model weights
+    caffeModelWeights = os.path.join(
+        caffe_proj_root, "NetProto", "net_best.caffemodel")
+
+    if os.path.isfile(caffeModelWeights):
+        print("Caffe model weights " + caffeModelWeights + " found.")
+    else:
+        print('Error : Caffe model weights "' + caffeModelWeights + '" not found.\n' +
+              '  Train neural network before processing it.')
+        sys.exit(0)
+
+    # Model definition
+    caffeModelDef = os.path.join(
+        caffe_proj_root, "NetProto", "net_deploy.prototxt")
+
+    if os.path.isfile(caffeModelDef):
+        print("Caffe model definition " + caffeModelDef + " found.")
+    else:
+        print('Error : Caffe model definition "' + caffeModelDef + '" not found.\n' +
+              '  Train neural network before processing it.')
+        sys.exit(0)
+
+    # Create network
+    caffe.set_mode_gpu()
+
+    net = caffe.Net(str(caffeModelDef),  # defines the structure of the model
+                    str(caffeModelWeights),  # contains the trained weights
+                    caffe.TEST)  # use test mode (e.g., don't perform dropout)
+
+    # set the size of the input (we can skip this if we're happy
+    # with the default; we can also change it later, e.g., for different batch
+    # sizes)
+    w = script_params['PATCH_RADIUS']
+
+    net.blobs['data'].reshape(script_params['DEPLOY_BATCH_SIZE'],  # batch size
+                              1,  # 1-channel
+                              2 * w + 1, 2 * w + 1)  # image size
+
+    # get list of test mha files
+    testMhaFiles = glob.glob(os.path.join(
+        testDataDir, "images", "*_zslab.mha"))
+
+    # segment all test .mha files
+    for mhaFile in testMhaFiles:
+
+        testAnimal = os.path.basename(os.path.splitext(mhaFile)[0])[:-6]
+        print "Segmenting ", testAnimal + ".mha", " ..."
+
+        # segment all slabs
+        for i in range(script_params['NUM_SLABS']):
+
+            inputFilename = os.path.join(
+                testDataDir, "images", str(i) + "_" + testAnimal + '_zslab.png')
+
+            outputFilename = os.path.join(
+                outputDir, str(i) + "_" + testAnimal + '_zslab.png')
+
+            segmentSlab(net, inputFilename, outputFilename)
+
+        # reconstruct volume from segmented slabs by mapping back to their MIP
+        # location
+        reconstructSegVolume(testAnimal, outputDir)
+
+        # segment tubes using ridge traversal
+        vascularModelFile = os.path.join(caffe_proj_root, 'vascularModel.mtp')
+
+        segmentTubes(testAnimal, vascularModelFile, outputDir,
+                     script_params['VESSEL_SEED_PROBABILITY'],
+                     script_params['VESSEL_SCALE'])
+
+        break
+
+if __name__ == "__main__":
+    run()

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -8,9 +8,12 @@ import os
 import sys
 import json
 import time
+import shutil
 
 import numpy as np
 import matplotlib.pyplot as plt
+
+import utils
 
 # Define paths
 script_params = json.load(open('params.json'))
@@ -18,16 +21,21 @@ caffe_root = str(script_params['CAFFE_SRC_ROOT'])
 hardDrive_root = str(script_params['CNN_DATA_ROOT'])
 
 # import caffe
-sys.path.insert(0, os.path.join(caffe_root, 'python')) # Add pycaffe
+sys.path.insert(0, os.path.join(caffe_root, 'python'))  # Add pycaffe
 import caffe
 from caffe import layers as L, params as P
+from caffe.proto import caffe_pb2
+import lmdb
 
 # Define file paths
-net_proto_path = os.path.join(caffe_root, 'data/SegmentVesselsUsingNeuralNetworks/NetProto')
+net_proto_path = os.path.join(
+    caffe_root, 'data/SegmentVesselsUsingNeuralNetworks/NetProto')
+snapshot_prefix = os.path.join(net_proto_path, 'net')
 
-train_net_path = os.path.join(net_proto_path, 'custom_auto_train.prototxt')
-test_net_path = os.path.join(net_proto_path, 'custom_auto_test.prototxt')
-solver_config_path = os.path.join(net_proto_path, 'custom_auto_solver.prototxt')
+train_net_path = os.path.join(net_proto_path, 'net_train.prototxt')
+test_net_path = os.path.join(net_proto_path, 'net_test.prototxt')
+deploy_net_path = os.path.join(net_proto_path, 'net_deploy.prototxt')
+solver_config_path = os.path.join(net_proto_path, 'net_solver.prototxt')
 
 train_results_dir = os.path.join(net_proto_path, 'train_results')
 if not os.path.exists(train_results_dir):
@@ -36,6 +44,8 @@ if not os.path.exists(train_results_dir):
 # Features square plot :
 #   Plot any layer's output features with the data parameter corresponding to
 #   solver.net.params['conv1'][0].data, where 'conv1' is the layer name.
+
+
 def squarePlot(data):
     """Take an array of shape (n, height, width) or (n, height, width, 3)
        and visualize each (height, width) thing in a grid of size approx. sqrt(n) by sqrt(n)"""
@@ -46,209 +56,422 @@ def squarePlot(data):
     # force the number of filters to be square
     n = int(np.ceil(np.sqrt(data.shape[0])))
     padding = (((0, n ** 2 - data.shape[0]),
-               (0, 1), (0, 1))                 # add some space between filters
+                (0, 1), (0, 1))                 # add some space between filters
                + ((0, 0),) * (data.ndim - 3))  # don't pad the last dimension (if there is one)
-    data = np.pad(data, padding, mode='constant', constant_values=1)  # pad with ones (white)
+    data = np.pad(data, padding, mode='constant',
+                  constant_values=1)  # pad with ones (white)
 
     # tile the filters into an image
-    data = data.reshape((n, n) + data.shape[1:]).transpose((0, 2, 1, 3) + tuple(range(4, data.ndim + 1)))
-    data = data.reshape((n * data.shape[1], n * data.shape[3]) + data.shape[4:])
-    filters=plt.imshow(data[:,:,0], cmap='gray', animated=True); plt.axis('off')
-    filters.set_data(data[:,:,0])
+    data = data.reshape(
+        (n, n) + data.shape[1:]).transpose((0, 2, 1, 3) + tuple(range(4, data.ndim + 1)))
+    data = data.reshape(
+        (n * data.shape[1], n * data.shape[3]) + data.shape[4:])
+
+    if len(data.shape) == 3:
+        data = data[:, :, 0]
+
+    vis = plt.imshow(data, cmap='gray', animated=True)
+    plt.axis('off')
+    vis.set_data(data)
     plt.draw()
     plt.pause(0.05)
 
+
 # Define net architecture
-def custom_net(lmdb, batch_size):
+def custom_net(batch_size, lmdb=None):
+
     # define your own net!
     n = caffe.NetSpec()
 
     # keep this data layer for all networks
-    n.data, n.label = L.Data(batch_size=batch_size, backend=P.Data.LMDB, source=lmdb,
-                             ntop=2, transform_param=dict(scale=1./255))
+    if lmdb:
 
-    # EDIT HERE to try different networks
-    # this single layer defines a simple linear classifier
-    # (in particular this defines a multiway logistic regression)
-    #n.score =   L.InnerProduct(n.data, num_output=10, weight_filler=dict(type='xavier'))
+        n.data, n.label = L.Data(batch_size=batch_size, backend=P.Data.LMDB, source=lmdb,
+                                 ntop=2, transform_param=dict(scale=1. / 255))
 
-    # EDIT HERE this is the LeNet variant we have already tried
-    n.conv1 = L.Convolution(n.data, kernel_size=6, num_output=48, weight_filler=dict(type='xavier'))
+    else:
+
+        # deploy mode
+        patch_size = 2 * script_params['PATCH_RADIUS'] + 1
+
+        n.data = L.Input(shape=[dict(dim=[batch_size, 1, patch_size, patch_size])],
+                         transform_param=dict(scale=1.0 / 255.0))
+
+    n.conv1 = L.Convolution(n.data, kernel_size=6,
+                            num_output=48, weight_filler=dict(type='xavier'))
     n.pool1 = L.Pooling(n.conv1, kernel_size=2, stride=2, pool=P.Pooling.MAX)
 
-    n.conv2 = L.Convolution(n.pool1, kernel_size=5, num_output=48, weight_filler=dict(type='xavier'))
+    n.conv2 = L.Convolution(n.pool1, kernel_size=5,
+                            num_output=48, weight_filler=dict(type='xavier'))
     n.pool2 = L.Pooling(n.conv2, kernel_size=2, stride=2, pool=P.Pooling.MAX)
 
-    n.conv3 = L.Convolution(n.pool2, kernel_size=4, num_output=48, weight_filler=dict(type='xavier'))
+    n.conv3 = L.Convolution(n.pool2, kernel_size=4,
+                            num_output=48, weight_filler=dict(type='xavier'))
     n.pool3 = L.Pooling(n.conv3, kernel_size=2, stride=2, pool=P.Pooling.MAX)
 
-    n.conv4 = L.Convolution(n.pool3, kernel_size=2, num_output=48, weight_filler=dict(type='xavier'))
+    n.conv4 = L.Convolution(n.pool3, kernel_size=2,
+                            num_output=48, weight_filler=dict(type='xavier'))
     n.pool4 = L.Pooling(n.conv4, kernel_size=2, stride=2, pool=P.Pooling.MAX)
 
-    n.fc1 =   L.InnerProduct(n.pool4, num_output=50, weight_filler=dict(type='xavier'))
+    n.fc1 = L.InnerProduct(n.pool4, num_output=50,
+                           weight_filler=dict(type='xavier'))
 
-    #EDIT HERE consider L.ELU or L.Sigmoid for the nonlinearity
-    #n.relu1 = L.ReLU(n.fc1, in_place=True)
-    #n.drop1 = L.Dropout(n.fc1, dropout_param=dict(dropout_ratio=0.5))
+    n.drop1 = L.Dropout(n.fc1, dropout_param=dict(dropout_ratio=0.5))
 
-    n.score = L.InnerProduct(n.fc1, num_output=2, weight_filler=dict(type='xavier'))
+    n.score = L.InnerProduct(n.drop1, num_output=2,
+                             weight_filler=dict(type='xavier'))
 
     # keep this loss layer for all networks
-    n.loss =  L.SoftmaxWithLoss(n.score, n.label)
+    if lmdb:
+
+        n.loss = L.SoftmaxWithLoss(n.score, n.label)
+
+    else:
+
+        # deploy mode
+        n.loss = L.Softmax(n.score)
 
     return n.to_proto()
 
-########
-# Main #
-########
-# Create testing and training net
-train_lmdb_path = os.path.join(caffe_root, 'data/SegmentVesselsUsingNeuralNetworks/Net_TrainData')
-with open(train_net_path, 'w') as f:
-    f.write(str(custom_net(train_lmdb_path, 256)))
 
-test_lmdb_path = os.path.join(caffe_root, 'data/SegmentVesselsUsingNeuralNetworks/Net_ValData')
-with open(test_net_path, 'w') as f:
-    f.write(str(custom_net(test_lmdb_path, 100)))
+def custom_solver(num_train_samples, num_test_samples):
 
-# Define solver
-from caffe.proto import caffe_pb2
-s = caffe_pb2.SolverParameter()
+    # Define and save solver params
+    solver_params = caffe_pb2.SolverParameter()
 
-# Set a seed for reproducible experiments:
-# this controls for randomization in training.
-s.random_seed = 0xCAFFE
+    # set solver_params type - "SGD", "Adam", and "Nesterov" etc
+    solver_params.type = script_params['SOLVER_TYPE']
 
-# Specify locations of the train and (maybe) test networks.
-s.train_net = train_net_path
-s.test_net.append(test_net_path)
-s.test_interval = 10000  # Test after every 500 training iterations.
-s.test_iter.append(1) # Test on 100 batches each time we test.
+    # set solver params parameters
+    solver_params.base_lr = script_params['BASE_LR']
+    solver_params.momentum = script_params['MOMENTUM']
+    solver_params.weight_decay = script_params['WEIGHT_DECAY']
 
-s.max_iter = 10000000  # no. of times to update the net (training iterations)
+    solver_params.lr_policy = script_params['LR_DECAY_POLICY']
+    solver_params.gamma = script_params['GAMMA']
+    solver_params.power = script_params['POWER']
 
-# EDIT HERE to try different solvers
-# solver types include "SGD", "Adam", and "Nesterov" among others.
-s.type = "SGD"
+    # Set a seed for reproducible experiments
+    solver_params.random_seed = 0xCAFFE
 
-# Set the initial learning rate for SGD.
-s.base_lr = 1e-2  # EDIT HERE to try different learning rates
+    # Specify locations of the train and (maybe) test networks.
+    solver_params.train_net = train_net_path
+    solver_params.test_net.append(test_net_path)
 
-# Set momentum to accelerate learning by
-# taking weighted average of current and previous updates.
-s.momentum = 0.9
+    # specify train iterations
+    # num passes through train dataset
+    num_train_epochs = script_params['NUM_TRAIN_EPOCHS']
+    train_batch_size = script_params['TRAIN_BATCH_SIZE']
+    num_train_iters_per_epoch = num_train_samples / train_batch_size
 
-# Set weight decay to regularize and prevent overfitting
-s.weight_decay = 5e-4
+    solver_params.max_iter = num_train_epochs * num_train_iters_per_epoch
 
-# Set `lr_policy` to define how the learning rate changes during training.
-# This is the same policy as our default LeNet.
-s.lr_policy = 'inv'
-s.gamma = 0.0001
-s.power = 0.75
+    # specify test interval and iterations
+    # num passes through test dataset
+    num_test_epochs = script_params['NUM_TEST_EPOCHS']
+    test_batch_size = script_params['TEST_BATCH_SIZE']
+    num_test_iters_per_epoch = num_test_samples / test_batch_size
 
-# EDIT HERE to try the fixed rate (and compare with adaptive solvers)
-# `fixed` is the simplest policy that keeps the learning rate constant.
-s.lr_policy = 'fixed'
+    # one pass through train dataset
+    solver_params.test_interval = num_train_iters_per_epoch
+    solver_params.test_iter.append(num_test_epochs * num_test_iters_per_epoch)
 
-# Display the current training loss and accuracy every 1000 iterations.
-s.display = 5000
+    solver_params.display = solver_params.test_interval
+    solver_params.snapshot = solver_params.test_interval
+    solver_params.snapshot_prefix = snapshot_prefix
 
-# Snapshots are files used to store networks we've trained.
-# We'll snapshot every 5K iterations -- twice during training.
-s.snapshot = 5000
-s.snapshot_prefix = os.path.join(net_proto_path, 'net')
+    solver_params.solver_mode = caffe_pb2.SolverParameter.GPU
 
-# Train on the GPU
-s.solver_mode = caffe_pb2.SolverParameter.GPU
-
-# Write the solver to a temporary file and return its filename.
-with open(solver_config_path, 'w') as f:
-    f.write(str(s))
-
-### load the solver and create train and test nets
-solver = None  # ignore this workaround for lmdb data (can't instantiate two solvers on the same data)
-solver = caffe.get_solver(solver_config_path)
-
-### solve
-niter = 5000  # EDIT HERE increase to train for longer
-test_interval = niter / 200
-
-# losses will also be stored in the log
-train_loss = np.zeros(niter)
-loss = 0
-test_acc = np.zeros(int(np.ceil(niter / test_interval)))
-
-caffe.set_mode_gpu() # Use GPU
-
-# the main solver loop
-fig = {}
-for key in solver.net.params.keys():
-    if key.startswith('conv'):
-        fig[key] = plt.figure()
-
-for it in range(niter):
-
-    # Uncomment time lines to get the step time
-    t=time.time()
-
-    solver.step(1)  # SGD by Caffe
-    print solver.net.blobs['data'].data[50, 0][25:35,27]
-
-    cur_loss = solver.net.blobs['loss'].data
-    print it, " : ", cur_loss, ". took ", (time.time()-t), " seconds"
-
-    # store the mean loss
-    loss += cur_loss
-    train_loss[it] = loss/(it+1)
-
-    # run a full test every so often
-    # (Caffe can also do this for us and write to a log, but we show here
-    # how to do it directly in Python, where more complicated things are easier.)
-    if it % test_interval == 0:
-        print 'Iteration', it, 'testing...'
-        correct = 0
-        for test_it in range(100):
-            solver.test_nets[0].forward()
-            correct += \
-                np.sum(solver.test_nets[0].blobs['score'].data.argmax(1) == solver.test_nets[0].blobs['label'].data)
-        test_acc[it // test_interval] = correct / 1e4
-        print "Test acc : ", test_acc[it // test_interval]
-        print "Train Loss ", it, train_loss[it]
-
-        # Plot hidden layer features
-        for key in solver.net.params.keys():
-
-            if key.startswith('conv'):
-
-                plt.figure(fig[key])
-
-                features=solver.net.params[key][0].data
-
-                squarePlot(features.transpose(0, 2, 3, 1))
-                plt.title('%s - %s' % (key, it))
-                plt.savefig(os.path.join(train_results_dir, 'filters_%s_%.9d.png' % (key, it)))
-
-# Show 10 first testing results
-plt.figure()
-plt.imshow(solver.test_nets[0].blobs['data'].data[:10, 0].transpose(1, 0, 2).reshape(65, 10*65), cmap='gray')
-plt.axis('off')
-
-print 'test labels:', solver.test_nets[0].blobs['label'].data[:10]
-print 'score:', solver.test_nets[0].blobs['score'].data[:10]
-print 'Argmax : ', solver.test_nets[0].blobs['score'].data.argmax(1)
-# plt.show()
-plt.savefig(os.path.join(train_results_dir, 'test_10.png'))
+    return solver_params
 
 
-# Plot output loss and test accuracy
-plt.figure()
-_, ax1 = plt.subplots()
-ax2 = ax1.twinx()
-ax1.plot(np.arange(niter), train_loss)
-ax2.plot(test_interval * np.arange(len(test_acc)), test_acc, 'r')
-ax1.set_xlabel('iteration')
-ax1.set_ylabel('train loss')
-ax2.set_ylabel('test accuracy')
-ax2.set_title('Custom Test Accuracy: {:.2f}'.format(test_acc[-1]))
-# plt.show()
-plt.savefig(os.path.join(train_results_dir, 'learning_curve.png'))
+def run():
+
+    sys.stdout = utils.Logger(os.path.join(net_proto_path, 'net_train.log'))
+
+    # Create testing and training net
+    train_batch_size = script_params['TRAIN_BATCH_SIZE']
+    train_lmdb_path = os.path.join(
+        caffe_root, 'data/SegmentVesselsUsingNeuralNetworks/Net_TrainData')
+    with open(train_net_path, 'w') as f:
+        f.write(str(custom_net(train_batch_size, train_lmdb_path)))
+
+    test_batch_size = script_params['TEST_BATCH_SIZE']
+    test_lmdb_path = os.path.join(
+        caffe_root, 'data/SegmentVesselsUsingNeuralNetworks/Net_ValData')
+    with open(test_net_path, 'w') as f:
+        f.write(str(custom_net(test_batch_size, test_lmdb_path)))
+
+    with open(deploy_net_path, 'w') as f:
+        f.write(str(custom_net(test_batch_size, None)))
+
+    # get number of train/test samples
+    num_train_samples = lmdb.open(
+        train_lmdb_path, readonly=True).stat()['entries']
+    num_test_samples = lmdb.open(
+        test_lmdb_path, readonly=True).stat()['entries']
+
+    # Define and save solver params
+    solver_params = custom_solver(num_train_samples, num_test_samples)
+
+    with open(solver_config_path, 'w') as f:
+        f.write(str(solver_params))
+
+    # load the solver and create train and test nets
+    # ignore this workaround for lmdb data (can't instantiate two solvers on
+    # the same data)
+    solver = None
+    solver = caffe.get_solver(solver_config_path)
+
+    # print the structure of the network
+    print '\nNumber of training samples = ', num_train_samples
+    print 'Number of testing samples = ', num_test_samples
+
+    print('\nNetwork structure ...')
+    for layer_name, blob in solver.net.blobs.iteritems():
+        print(layer_name + '\t' + str(blob.data.shape))
+
+    # print parameters at each network layer
+    print('\nNetwork parameters ...')
+
+    num_params = 0
+    for layer_name, param in solver.net.params.iteritems():
+        print layer_name + '\t' + str(param[0].data.shape), str(param[1].data.shape),
+
+        cur_num_params = np.prod(param[0].data.shape) + param[1].data.shape
+        print '\t%d parameters (%.2f MB)' % (cur_num_params, cur_num_params * 8.0 / 10.0**6)
+        num_params += cur_num_params
+
+    print 'Total number of params : %d (%.3f MB)' % (num_params, num_params * 8.0 / 10**6)
+
+    # ask if user wants to start training
+    flag_train = raw_input('start training (y/n)?')
+
+    if flag_train != 'y':
+        sys.exit(0)
+
+    # solve
+    caffe.set_mode_gpu()  # Use GPU
+
+    fig = {}
+    for layer_name in solver.net.params.keys():
+        if layer_name.startswith('conv'):
+            fig[layer_name] = plt.figure()
+
+    num_train_epochs = script_params['NUM_TRAIN_EPOCHS']
+    train_batch_size = script_params['TRAIN_BATCH_SIZE']
+    num_train_iters_per_epoch = num_train_samples / train_batch_size
+    num_train_iters = num_train_epochs * num_train_iters_per_epoch
+
+    num_test_epochs = script_params['NUM_TEST_EPOCHS']
+    test_batch_size = script_params['TEST_BATCH_SIZE']
+    num_test_iters_per_epoch = num_test_samples / test_batch_size
+    num_test_iters = num_test_epochs * num_test_iters_per_epoch
+
+    assert(num_train_iters == solver_params.max_iter)
+    assert(num_test_iters == solver_params.test_iter[0])
+    assert(num_train_iters_per_epoch == solver_params.test_interval)
+
+    train_loss = np.zeros(num_train_iters)
+    test_acc = np.zeros(num_train_epochs)
+    test_loss = np.zeros_like(test_acc)
+
+    it_train = 0
+
+    best_iter = -1
+    best_epoch = -1
+    best_acc = 0
+
+    for ep_train in range(num_train_epochs):
+
+        # make one pass through training data
+        t = time.time()
+
+        mean_train_loss = 0
+
+        for i in range(num_train_iters_per_epoch):
+
+            # make one training step
+            solver.step(1)  # SGD by Caffe
+
+            # get and store the loss
+            cur_loss = solver.net.blobs['loss'].data
+
+            train_loss[it_train] = cur_loss
+
+            mean_train_loss += cur_loss
+
+            it_train += 1
+
+        epoch_train_time = time.time() - t
+
+        mean_train_loss /= num_train_iters_per_epoch
+
+        # validate model
+        correct = 0.0
+        num_test_cases = 0.0
+        mean_test_loss = 0.0
+
+        t = time.time()
+
+        for ep_test in range(num_test_epochs):
+
+            for i in range(num_test_iters_per_epoch):
+
+                # make one validation step
+                solver.test_nets[0].forward()
+
+                # compute and store test accuracy
+                pred_labels = solver.test_nets[0].blobs['score'].data.argmax(1)
+                true_labels = solver.test_nets[0].blobs['label'].data
+                correct += np.sum(pred_labels == true_labels)
+                num_test_cases += len(pred_labels)
+
+                # compute and store test loss
+                mean_test_loss += solver.test_nets[0].blobs['loss'].data
+
+        mean_test_loss /= num_test_iters
+        cur_acc = correct / num_test_cases
+
+        test_acc[ep_train] = cur_acc
+        test_loss[ep_train] = mean_test_loss
+
+        if cur_acc > best_acc:
+
+            best_iter = it_train
+            best_epoch = ep_train
+            best_acc = cur_acc
+
+        test_time = time.time() - t
+
+        # print status
+        print 'Training epoch %s / %s ...' % (ep_train + 1, num_train_epochs)
+
+        print '\tTrain loss mean = %s' % mean_train_loss
+        print '\tNo of training iterations finished = %s' % it_train
+        print '\tEpoch training time = %s' % epoch_train_time
+
+        print "\tTest loss mean = %s, accuracy = %s" % (mean_test_loss, cur_acc)
+        print "\tTesting time = %s" % test_time
+
+        # Visualize convolutional filters at each layer
+        for layer_name in solver.net.params.keys():
+
+            if layer_name.startswith('conv'):
+
+                plt.figure(fig[layer_name].number)
+
+                features = solver.net.params[layer_name][0].data
+
+                n_filters, n_channels, h, w = features.shape
+                n_images = n_filters * n_channels
+
+                squarePlot(features.reshape(n_images, h, w))
+
+                plt.title('%s - %s - Iter %s - Epoch %s' %
+                          (layer_name, str(features.shape),
+                           it_train, ep_train))
+                plt.savefig(
+                    os.path.join(
+                        train_results_dir,
+                        'filters_%s_ep_%.3d_it_%.7d.png' % (layer_name,
+                                                            ep_train,
+                                                            it_train)
+                    )
+                )
+
+    print 'Test accuracy : ', test_acc
+    print 'Test loss     : ', test_loss
+
+    # save best model
+    print 'Best model: accuracy = %s, iter = %s, epoch = %s' % (best_acc,
+                                                                best_iter,
+                                                                best_epoch)
+
+    shutil.copyfile(
+        snapshot_prefix + '_iter_%d.caffemodel' % best_iter,
+        snapshot_prefix + '_best.caffemodel'
+    )
+    shutil.copyfile(
+        snapshot_prefix + '_iter_%d.solverstate' % best_iter,
+        snapshot_prefix + '_best.solverstate'
+    )
+
+    # Plot learning curve
+    fig_learning_curve = plt.figure()
+
+    ax1 = fig_learning_curve.add_subplot(111)
+
+    train_iter_ticks = np.arange(
+        num_train_iters, dtype=np.double) / num_train_iters_per_epoch
+    ln1 = ax1.plot(train_iter_ticks, train_loss, 'g', label='train loss')
+
+    ax1.plot(best_epoch, best_acc, 'k*', markersize=10)
+
+    ax1.set_xlabel('Epochs')
+    ax1.set_ylabel('train/test loss')
+    ax1.set_xlim([0, num_train_epochs])
+
+    ax2 = ax1.twinx()
+
+    test_iter_ticks = np.arange(num_train_epochs, dtype=np.double)
+    ln2 = ax1.plot(test_iter_ticks, test_loss, 'b', label='test loss')
+    ln3 = ax2.plot(test_iter_ticks, test_acc, 'r', label='test accuracy')
+
+    ax2.grid()
+    ax2.set_ylabel('test accuracy')
+    ax2.set_title('Learning curve : best epoch = %d, iter = %d' %
+                  (best_epoch, best_iter))
+    ax2.set_xlim([0, num_train_epochs])
+    ax2.set_ylim([0.0, 1.0])
+
+    lns = ln1 + ln2 + ln3
+    labels = [l.get_label() for l in lns]
+    ax2.legend(lns, labels, loc=0)
+
+    fig_learning_curve.savefig(os.path.join(
+        train_results_dir, 'learning_curve.png'))
+
+    # Show sample images from each cell of the confusion matrix
+    pred_labels = solver.test_nets[0].blobs['score'].data.argmax(1)
+    true_labels = solver.test_nets[0].blobs['label'].data
+
+    tp = np.where(np.logical_and(true_labels == 1, pred_labels == 1))[0]
+    tp_data = solver.test_nets[0].blobs['data'].data[tp, 0]
+    tp_percent = len(tp) * 100.0 / test_batch_size
+    print 'True Positives : %d / %d (%.2f%%)' % (len(tp), test_batch_size, tp_percent)
+    plt.figure()
+    squarePlot(tp_data)
+    plt.title('True Positive Examples - %.2f%%' % tp_percent)
+    plt.savefig(os.path.join(train_results_dir, 'sample_true_positives.png'))
+
+    tn = np.where(np.logical_and(true_labels == 0, pred_labels == 0))[0]
+    tn_data = solver.test_nets[0].blobs['data'].data[tn, 0]
+    tn_percent = len(tn) * 100.0 / test_batch_size
+    print 'True Negatives : %d / %d (%.2f%%)' % (len(tn), test_batch_size, tn_percent)
+    plt.figure()
+    squarePlot(tn_data)
+    plt.title('True Negative Examples - %.2f%%' % tn_percent)
+    plt.savefig(os.path.join(train_results_dir, 'sample_true_negatives.png'))
+
+    fp = np.where(np.logical_and(true_labels == 0, pred_labels == 1))[0]
+    fp_data = solver.test_nets[0].blobs['data'].data[fp, 0]
+    fp_percent = len(fp) * 100.0 / test_batch_size
+    print 'False Positives : %d / %d (%.2f%%) ' % (len(fp), test_batch_size, fp_percent)
+    plt.figure()
+    squarePlot(fp_data)
+    plt.title('False Positive Examples - %.2f%%' % fp_percent)
+    plt.savefig(os.path.join(train_results_dir, 'sample_false_positives.png'))
+
+    fn = np.where(np.logical_and(true_labels == 1, pred_labels == 0))[0]
+    fn_data = solver.test_nets[0].blobs['data'].data[fn, 0]
+    fn_percent = len(fn) * 100.0 / test_batch_size
+    print 'False Negatives : %d / %d (%.2f%%)' % (len(fn), test_batch_size, fn_percent)
+    plt.figure()
+    squarePlot(fn_data)
+    plt.title('False Negative Examples - %.2f%%' % fn_percent)
+    plt.savefig(os.path.join(train_results_dir, 'sample_false_negatives.png'))
+
+
+if __name__ == "__main__":
+    run()

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/UnShrink.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/UnShrink.py
@@ -7,33 +7,30 @@
 #
 ###########################################################################
 
-import sys
+import json
 import os
-import subprocess
+import sys
 
-import matplotlib.image as mpimg
-import matplotlib.pyplot as plt
-
-import numpy as np
-
-from PIL import Image
-
-## Append ITK libs
-sys.path.append('/home/lucas/Projects/ITK-Release/Wrapping/Generators/Python')
-sys.path.append('/home/lucas/Projects/ITK-Release/Modules/ThirdParty/VNL/src/vxl/lib')
+## Append ITK lib dirs to PYTHONPATH and import itk
+sys.path.append(os.path.join(os.environ['TubeTK_BUILD_DIR'], 'ITK-build/Wrapping/Generators/Python'))
+sys.path.append(os.path.join(os.environ['TubeTK_BUILD_DIR'], 'ITK-build/Modules/ThirdParty/VNL/src/vxl/lib'))
 import itk
 
-# Path variables
-hardDrive_root = "/media/lucas/krs0014/"
+# Define paths
+script_params = json.load(open('params.json'))
+caffe_root = script_params['CAFFE_SRC_ROOT']
+hardDrive_root = script_params['CNN_DATA_ROOT']
+
+hardDrive_vseg_root = os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks")
 
 # Animal name. WARNING: This script will look for the animal point map generated
 #  by ConvertData.py and saved in hardDrive_root + "SegmentVesselsUsingNeuralNetworks/testing/images/
 #  The animal name has to come from the testing set, otherwise re-run the ConvertData.py
 #  script with the appropriate location
-animal = "pp07_A34_left"
+animal = "pp07_A36_left"
 
-pointImage = hardDrive_root + "SegmentVesselsUsingNeuralNetworks/testing/points/"+ animal +"_points.mha"
-vesselImage = hardDrive_root + "SegmentVesselsUsingNeuralNetworks/output/"+ animal +".png.mha"
+pointImage = str(os.path.join(hardDrive_vseg_root, "testing/points", animal + "_points.mha"))
+vesselImage = str(os.path.join(hardDrive_vseg_root, "output", animal + ".png.mha"))
 
 ########
 # Main #
@@ -42,7 +39,7 @@ PixelType = itk.F
 Dimension = 3
 
 # Read segmented vessels slabs
-ImageType=itk.Image[PixelType,Dimension]
+ImageType=itk.Image[PixelType, Dimension]
 ReaderType = itk.ImageFileReader[ImageType]
 reader = ReaderType.New()
 reader.SetFileName(vesselImage)
@@ -51,7 +48,7 @@ vesselImg = reader.GetOutput()
 vesselBuf = itk.PyBuffer[ImageType].GetArrayFromImage(vesselImg)
 
 # Read point map image
-VectorImageType=itk.VectorImage[PixelType,Dimension]
+VectorImageType=itk.VectorImage[PixelType, Dimension]
 VectorReaderType = itk.ImageFileReader[VectorImageType]
 vectorReader = VectorReaderType.New()
 vectorReader.SetFileName(pointImage)
@@ -61,27 +58,27 @@ buf = itk.PyBuffer[VectorImageType].GetArrayFromImage(img)
 
 # Create output 3D image
 RegionType=itk.ImageRegion[Dimension]
-region = itk.ImageRegion[Dimension]([0,0,0],[512,512,393])
+region = itk.ImageRegion[Dimension]([0,0,0], [512,512,393])
 img3d = ImageType.New()
 img3d.CopyInformation(img)
 img3d.SetRegions(region)
 img3d.Allocate()
-img3d.SetSpacing([0.05,0.05,0.05]) #WARNING: Spacing and Origin should be read from the input .mhd ultrasound scan
+img3d.SetSpacing([0.05,0.05,0.05])  # WARNING: Spacing and Origin should be read from the input .mhd ultrasound scan
 img3d.SetOrigin([0,0,0])
 
 # Iterate through slabs
 for slabIdx in range(0,vesselBuf.shape[0]):
-  print "Reconstructing slab",slabIdx,"/",vesselBuf.shape[0]-1,"..."
-  for i in range(vesselBuf.shape[1]):
-    for j in range(vesselBuf.shape[2]):
-      if vesselBuf[slabIdx,i,j] > 249: #WARNING: Threshold value can be changed
-        # Get current bright pixel 3D position
-        x=float(buf[slabIdx,i,j,0])
-        y=float(buf[slabIdx,i,j,1])
-        z=float(buf[slabIdx,i,j,2])
-        # Paint pixel back into the 3D image
-        index = img3d.TransformPhysicalPointToIndex([x,y,z])
-        img3d.SetPixel(index, 255)
+    print "Reconstructing slab",slabIdx,"/",vesselBuf.shape[0]-1,"..."
+    for i in range(vesselBuf.shape[1]):
+        for j in range(vesselBuf.shape[2]):
+            if vesselBuf[slabIdx,i,j] > 249: # WARNING: Threshold value can be changed
+                # Get current bright pixel 3D position
+                x=float(buf[slabIdx,i,j,0])
+                y=float(buf[slabIdx,i,j,1])
+                z=float(buf[slabIdx,i,j,2])
+                # Paint pixel back into the 3D image
+                index = img3d.TransformPhysicalPointToIndex([x,y,z])
+                img3d.SetPixel(index, 255)
 
 # Blur image to fill gaps between painted pixels.
 BlurFilterType=itk.DiscreteGaussianImageFilter[ImageType,ImageType]
@@ -90,10 +87,10 @@ blurFilter.SetInput(img3d)
 blurFilter.SetVariance(1)
 blurFilter.SetMaximumKernelWidth(1)
 
-print("..Writing output ..")
+print("Writing output ..")
 WriterType = itk.ImageFileWriter[ImageType]
 writer = WriterType.New()
 writer.UseCompressionOn()
-writer.SetFileName( hardDrive_root + "SegmentVesselsUsingNeuralNetworks/output/3d.mha")
+writer.SetFileName(str(os.path.join(hardDrive_vseg_root, "output/3d.mha")))
 writer.SetInput( blurFilter.GetOutput() )
 writer.Update()

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/create_imageset.sh
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/create_imageset.sh
@@ -2,12 +2,15 @@
 # Create the imagenet lmdb inputs
 # N.B. set the path to the imagenet train + val data dirs
 
-EXAMPLE=${CAFFE_SRC_ROOT}/data/SegmentVesselsUsingNeuralNetworks
-DATA=${CAFFE_SRC_ROOT}/data/SegmentVesselsUsingNeuralNetworks
-TOOLS=${CAFFE_SRC_ROOT}/build/tools
+CAFFE_SRC_ROOT=`jq '.CAFFE_SRC_ROOT' params.json`
+CNN_DATA_ROOT=`jq '.CNN_DATA_ROOT' params.json`
+PROJECT_REL_PATH=`jq '.PROJECT_REL_PATH' params.json`
 
-TRAIN_DATA_ROOT=${CNN_DATA_ROOT}/SegmentVesselsUsingNeuralNetworks/training/out/
-VAL_DATA_ROOT=${CNN_DATA_ROOT}/SegmentVesselsUsingNeuralNetworks/testing/out/
+CAFFE_PROJ_ROOT="${CAFFE_SRC_ROOT}/data/${PROJECT_REL_PATH}"
+CAFFE_TOOLS_DIR="${CAFFE_SRC_ROOT}/build/tools"
+
+TRAIN_DATA_ROOT="${CNN_DATA_ROOT}/${PROJECT_REL_PATH}/training/patches/"
+VAL_DATA_ROOT="${CNN_DATA_ROOT}/${PROJECT_REL_PATH}/testing/patches/"
 
 # Set RESIZE=true to resize the images to 256x256. Leave as false if images have
 # already been resized using another tool.
@@ -23,45 +26,45 @@ fi
 if [ ! -d "$TRAIN_DATA_ROOT" ]; then
   echo "Error: TRAIN_DATA_ROOT is not a path to a directory: $TRAIN_DATA_ROOT"
   echo "Set the TRAIN_DATA_ROOT variable in create_imagenet.sh to the path" \
-       "where the ImageNet training data is stored."
+       "where the training patches data is stored."
   exit 1
 fi
 
 if [ ! -d "$VAL_DATA_ROOT" ]; then
   echo "Error: VAL_DATA_ROOT is not a path to a directory: $VAL_DATA_ROOT"
   echo "Set the VAL_DATA_ROOT variable in create_imagenet.sh to the path" \
-       "where the ImageNet validation data is stored."
+       "where the validation patches data is stored."
   exit 1
 fi
 
 echo "Creating train lmdb..."
 
-GLOG_logtostderr=1 $TOOLS/convert_imageset \
+GLOG_logtostderr=1 $CAFFE_TOOLS_DIR/convert_imageset \
     --resize_height=$RESIZE_HEIGHT \
     --resize_width=$RESIZE_WIDTH \
     --shuffle \
     --gray \
     $TRAIN_DATA_ROOT \
-    $DATA/train.txt \
-    $EXAMPLE/Net_TrainData
+    $TRAIN_DATA_ROOT/train.txt \
+    $CAFFE_PROJ_ROOT/Net_TrainData
 
 echo "Creating val lmdb..."
 
-GLOG_logtostderr=1 $TOOLS/convert_imageset \
+GLOG_logtostderr=1 $CAFFE_TOOLS_DIR/convert_imageset \
     --resize_height=$RESIZE_HEIGHT \
     --resize_width=$RESIZE_WIDTH \
     --shuffle \
     --gray \
     $VAL_DATA_ROOT \
-    $DATA/val.txt \
-    $EXAMPLE/Net_ValData
+    $VAL_DATA_ROOT/val.txt \
+    $CAFFE_PROJ_ROOT/Net_ValData
 
 
 
 # echo "Creating train mean ... "
-# $TOOLS/compute_image_mean $DATA/Net_TrainData/ $DATA/Net_TrainData/mean.binaryproto
+# $CAFFE_TOOLS_DIR/compute_image_mean $DATA/Net_TrainData/ $DATA/Net_TrainData/mean.binaryproto
 #
 # echo "Creating val mean ... "
-# $TOOLS/compute_image_mean $DATA/Net_ValData/ $DATA/Net_ValData/mean.binaryproto
+# $CAFFE_TOOLS_DIR/compute_image_mean $DATA/Net_ValData/ $DATA/Net_ValData/mean.binaryproto
 
 echo "Done."

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/params.json
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/params.json
@@ -1,4 +1,23 @@
 {
     "CNN_DATA_ROOT": "/media/krs0014",
-    "CAFFE_SRC_ROOT": "/home/cdeepakroy/work/Libs/caffe"
+    "CAFFE_SRC_ROOT": "/home/cdeepakroy/work/Libs/caffe",
+    "PROJECT_REL_PATH": "SegmentVesselsUsingNeuralNetworks",
+    "PATCH_RADIUS": 32,
+    "NUM_SLABS": 10,
+    "SLAB_OVERLAP": 20,
+    "NEGATIVES_NEAR_VESSEL_BOUNDARY": 0.8,
+    "NUM_TRAIN_EPOCHS": 10,
+    "NUM_TEST_EPOCHS": 1,
+    "TRAIN_BATCH_SIZE": 1024,
+    "TEST_BATCH_SIZE": 1024,
+    "DEPLOY_BATCH_SIZE": 4096,
+    "SOLVER_TYPE": "SGD",
+    "BASE_LR": 0.01,
+    "MOMENTUM": 0.9,
+    "WEIGHT_DECAY": 1e-4,
+    "LR_DECAY_POLICY": "inv",
+    "GAMMA": 1e-4,
+    "POWER": 0.75,
+    "VESSEL_SEED_PROBABILITY": 0.95,
+    "VESSEL_SCALE": 0.1
 }

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/reconstructSlabs.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/reconstructSlabs.py
@@ -8,42 +8,48 @@
 #
 ###########################################################################
 
+import json
+import os
 import sys
+
 ## Append ITK libs
-sys.path.append('/home/lucas/Projects/ITK-Release/Wrapping/Generators/Python')
-sys.path.append('/home/lucas/Projects/ITK-Release/Modules/ThirdParty/VNL/src/vxl/lib')
+sys.path.append(os.path.join(os.environ['TubeTK_BUILD_DIR'], 'ITK-build/Wrapping/Generators/Python'))
+sys.path.append(os.path.join(os.environ['TubeTK_BUILD_DIR'], 'ITK-build/Modules/ThirdParty/VNL/src/vxl/lib'))
 import itk
 
-def reconstructSlabs( animalName, directory ):
-  PixelType = itk.UC
-  Dimension = 3
-  ImageType=itk.Image[PixelType,Dimension]
 
-  SeriesReaderType = itk.ImageSeriesReader[ImageType]
-  WriterType = itk.ImageFileWriter[ImageType]
+def reconstructSlabs(animalName, directory):
 
-  seriesReader = SeriesReaderType.New()
-  writer = WriterType.New()
+    PixelType = itk.UC
+    Dimension = 3
+    ImageType=itk.Image[PixelType,Dimension]
 
-  NameGeneratorType = itk.NumericSeriesFileNames
-  nameGenerator = NameGeneratorType.New()
+    SeriesReaderType = itk.ImageSeriesReader[ImageType]
+    WriterType = itk.ImageFileWriter[ImageType]
 
-  nameGenerator.SetStartIndex( 0 )
-  nameGenerator.SetEndIndex( 9 )
-  nameGenerator.SetIncrementIndex( 1 )
-  nameGenerator.SetSeriesFormat( directory + "%d_" + animalName )
+    seriesReader = SeriesReaderType.New()
+    writer = WriterType.New()
 
-  #seriesReader.SetImageIO( itk.PNGImageIO.New() )
-  seriesReader.SetFileNames( nameGenerator.GetFileNames() )
-  writer.SetFileName( directory + animalName + ".mha" )
-  writer.SetInput( seriesReader.GetOutput() )
-  writer.Update()
+    NameGeneratorType = itk.NumericSeriesFileNames
+    nameGenerator = NameGeneratorType.New()
 
+    nameGenerator.SetStartIndex( 0 )
+    nameGenerator.SetEndIndex( 9 )
+    nameGenerator.SetIncrementIndex( 1 )
+    nameGenerator.SetSeriesFormat(str(os.path.join(directory, "%d_" + animalName)))
 
+    #  seriesReader.SetImageIO( itk.PNGImageIO.New() )
+    seriesReader.SetFileNames( nameGenerator.GetFileNames() )
+    writer.SetFileName(str(os.path.join(directory, animalName + ".mha")))
+    writer.SetInput(seriesReader.GetOutput())
+    writer.Update()
 
-hardDrive_root = "/media/lucas/krs0014/"
+# Define paths
+script_params = json.load(open('params.json'))
+caffe_root = script_params['CAFFE_SRC_ROOT']
+hardDrive_root = script_params['CNN_DATA_ROOT']
 
-outputDir = hardDrive_root + "SegmentVesselsUsingNeuralNetworks/output/"
-outputAnimal = "pp07_A34_left.png" #WARNING Hardcoded
+outputDir = os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/output/")
+outputAnimal = "pp07_A36_left.png"  # WARNING Hardcoded
 
-reconstructSlabs( outputAnimal, outputDir )
+reconstructSlabs(outputAnimal, outputDir)

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/saveSlabs.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/saveSlabs.py
@@ -7,84 +7,92 @@
 #
 ###########################################################################
 
-import os, glob, sys, subprocess, json
+import os
+import glob
+import sys
+import subprocess
+import json
 
-import matplotlib.image as mpimg
 import matplotlib.pyplot as plt
 
-import numpy as np
-
-## Append ITK libs
+# Append ITK libs
 sys.path.append(os.path.join(os.environ['TubeTK_BUILD_DIR'], 'ITK-build',
                              'Wrapping/Generators/Python'))
 sys.path.append(os.path.join(os.environ['TubeTK_BUILD_DIR'], 'ITK-build',
                              'Modules/ThirdParty/VNL/src/vxl/lib'))
-
 import itk
 
-# Compute Training mask
-def computeTrainingMask( expertInput, trainingMaskOutput ):
-  subprocess.call( ["SegmentBinaryImageSkeleton",
-                    expertInput,
-                    expertInput+"tmp.png"] )
-  subprocess.call( ["ImageMath", expertInput,
-                    "-t", "0", "0.5", "0", "255",
-                    "-W", "0", expertInput+"tmp2.png",
-                    "-M", "1", "1", "255", "0",
-                    "-a", "1", "-1", expertInput+"tmp2.png",
-                    "-a", "0.5", "255", expertInput+"tmp.png",
-                    "-W", "0", trainingMaskOutput] )
-  subprocess.call( ["rm", "-rf",expertInput+"tmp.png"])
-  subprocess.call( ["rm", "-rf",expertInput+"tmp2.png"])
 
-  # WARNING: Couldn't write to PNG using the implemented CLI
-  #subprocess.call( ["ComputeTrainingMask",
-                    #expertInput,
-                    #trainingMaskOutput,
-                    #"--notVesselWidth","1"] )
+# Compute Training mask
+def computeTrainingMask(expertInput, trainingMaskOutput):
+    subprocess.call(["SegmentBinaryImageSkeleton",
+                     expertInput,
+                     expertInput + "tmp.png"])
+    subprocess.call(["ImageMath", expertInput,
+                     "-t", "0", "0.5", "0", "255",
+                     "-W", "0", expertInput + "tmp2.png",
+                     "-M", "1", "1", "255", "0",
+                     "-a", "1", "-1", expertInput + "tmp2.png",
+                     "-a", "0.5", "255", expertInput + "tmp.png",
+                     "-W", "0", trainingMaskOutput])
+    subprocess.call(["rm", "-rf", expertInput + "tmp.png"])
+    subprocess.call(["rm", "-rf", expertInput + "tmp2.png"])
+
+    # WARNING: Couldn't write to PNG using the implemented CLI
+    # subprocess.call( ["ComputeTrainingMask",
+    # expertInput,
+    # trainingMaskOutput,
+    #"--notVesselWidth","1"] )
+
 
 # Save slab
-def saveSlabs( fileList ):
+def saveSlabs(mhaFileList):
 
-  PixelType = itk.F
-  Dimension = 3
-  ImageType=itk.Image[PixelType,Dimension]
-  ReaderType = itk.ImageFileReader[ImageType]
+    PixelType = itk.F
+    Dimension = 3
+    ImageType = itk.Image[PixelType, Dimension]
+    ReaderType = itk.ImageFileReader[ImageType]
 
-  for fname in fileList:
+    for mhaFile in mhaFileList:
 
-    print fname
+        print(mhaFile)
 
-    reader = ReaderType.New()
-    reader.SetFileName(str(fname))
-    reader.Update()
-    img = reader.GetOutput()
-    buf = itk.PyBuffer[ImageType].GetArrayFromImage(img)
+        reader = ReaderType.New()
+        reader.SetFileName(str(mhaFile))
+        reader.Update()
+        img = reader.GetOutput()
+        buf = itk.PyBuffer[ImageType].GetArrayFromImage(img)
 
-    # filenames definition
-    filePrefix = os.path.basename(os.path.splitext(fname)[0])
-    fileDirectory = os.path.dirname(os.path.abspath(fname))
+        # filenames definition
+        filePrefix = os.path.basename(os.path.splitext(mhaFile)[0])
+        fileDirectory = os.path.dirname(os.path.abspath(mhaFile))
 
-    # Iterate through each slab
-    for i in range(0,buf.shape[0]):
+        # Iterate through each slab
+        for i in range(0, buf.shape[0]):
 
-      outputImage = os.path.join(fileDirectory, str(i) + "_" + filePrefix + ".png")
-      plt.imsave( outputImage, buf[i,:,:],cmap='Greys_r' )
+            outputImage = os.path.join(
+                fileDirectory, str(i) + "_" + filePrefix + ".png")
+            plt.imsave(outputImage, buf[i, :, :], cmap='Greys_r')
 
-      # Compute the expert training mask
-      if "expert" in outputImage:
-        computeTrainingMask( outputImage, outputImage )
+            # Compute the expert training mask
+            if "expert" in outputImage:
+                computeTrainingMask(outputImage, outputImage)
 
 # Path variables
 script_params = json.load(open('params.json'))
 caffe_root = script_params['CAFFE_SRC_ROOT']
 hardDrive_root = script_params['CNN_DATA_ROOT']
+proj_rel_path = script_params['PROJECT_REL_PATH']
 
-trainOutputDir = os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/training/*")
-testOutputDir = os.path.join(hardDrive_root, "SegmentVesselsUsingNeuralNetworks/testing/*")
+caffe_proj_root = os.path.join(caffe_root, "data", proj_rel_path)
+hardDrive_proj_root = os.path.join(hardDrive_root, proj_rel_path)
 
-trainFiles = glob.glob( os.path.join( trainOutputDir, "*.mha" ) )
-testFiles = glob.glob( os.path.join( testOutputDir, "*.mha" ) )
+trainDataDir = os.path.join(hardDrive_proj_root, "training")
+valDataDir = os.path.join(hardDrive_proj_root, "testing")
 
-saveSlabs(trainFiles)
-saveSlabs(testFiles)
+
+saveSlabs(glob.glob(os.path.join(trainDataDir, "images", "*.mha")))
+saveSlabs(glob.glob(os.path.join(trainDataDir, "expert", "*.mha")))
+
+saveSlabs(glob.glob(os.path.join(valDataDir, "images", "*.mha")))
+saveSlabs(glob.glob(os.path.join(valDataDir, "expert", "*.mha")))


### PR DESCRIPTION
This PR consolidates the data preprocessing, CNN training and testing into just three scripts for which involved running several scripts earlier:

* **PrepareTrainingData.py** - This generates the Z-MIP slabs for all datasets, splits control and tumor datasets equally into training and validation sets, generates +ve and -ve patches for training the CNN, and creates the caffe LMDB files 

* **TrainNet.py** - This defines the CNN architecture, trains the CNN in an epoch-wise (earlier we were doing in terms of iteration), saves the CNN filters after each epoch, plots the learning curve, and random samples of patches falling in each element of the confusion matrix for debugging.

* **TestNet.py** - This uses the trained CNN to segment vessels on all datasets in the testing set. Specifically, it applies the CNN to segment patches in the Z_MIP slabs, takes the vessel probability volume and maps it back to the input image space, thresholds the probability volume at a high confidence threshold to generate vessel seeds, and then uses TubeTK's SegmentTubes Application to trace vessels starting from these seed points.

This PR also reduces hardcoding all old files (ConvertData.py, PreProcessing.py, ProcessNet.py, reconstructSlabs.py, saveSlabs.py, Unshrink.py),  and exposes things in params.json as necessary. Eventually I plan to remove these old files and keep only the three consolidated scripts mentioned above.
