### PR TITLE
SegmentVesselsUsingNeuralNetworks small bug fixes

### DIFF
--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
@@ -51,21 +51,26 @@ def createExpertSegmentationMask(inputImageFile, treFile, outputExpertSegFile):
 # Shrink images
 def shrink(inputImage, expertImage, outputImagePrefix):
 
-    shrinked_size = "-n 512,512,%d" % script_params["NUM_SLABS"]
-    window_overlap = "-o 0,0,%d" % script_params["SLAB_OVERLAP"]
+    shrinked_size = "512,512,%d" % script_params["NUM_SLABS"]
+    window_overlap = "0,0,%d" % script_params["SLAB_OVERLAP"]
 
-    subprocess.call(["ShrinkImage", shrinked_size, window_overlap,
+    subprocess.call(["ShrinkImage",
+                     "-n", shrinked_size,
+                     "-o", window_overlap,
                      "-p", outputImagePrefix + "_zslab_points.mha",
                      inputImage,
                      outputImagePrefix + "_zslab.mha"])
 
-    subprocess.call(["ShrinkImage", shrinked_size, window_overlap,
+    subprocess.call(["ShrinkImage",
+                     "-n", shrinked_size,
+                     "-o", window_overlap,
                      "-i", outputImagePrefix + "_zslab_points.mha",
                      expertImage,
                      outputImagePrefix + "_zslab_expert.mha"])
 
     """
-    subprocess.call(["ShrinkImage", shrinked_size,
+    subprocess.call(["ShrinkImage",
+                     "-n", shrinked_size,
                      expertImage,
                      outputImagePrefix + "_zslab_expert.mha"])
     """

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
@@ -9,6 +9,8 @@ import glob
 import subprocess
 import time
 
+import matplotlib
+matplotlib.use('AGG')
 import matplotlib.pyplot as plt
 import numpy as np
 import skimage.io

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -220,6 +220,10 @@ def run():
     with open(solver_config_path, 'w') as f:
         f.write(str(solver_params))
 
+    # Must be called before instantiating solver due to potential
+    # Caffe bug
+    caffe.set_mode_gpu()  # Use GPU
+
     # load the solver and create train and test nets
     # ignore this workaround for lmdb data (can't instantiate two solvers on
     # the same data)
@@ -254,7 +258,6 @@ def run():
         sys.exit(0)
 
     # solve
-    caffe.set_mode_gpu()  # Use GPU
 
     fig = {}
     for layer_name in solver.net.params.keys():

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -11,6 +11,9 @@ import time
 import shutil
 
 import numpy as np
+
+import matplotlib
+matplotlib.use('AGG')
 import matplotlib.pyplot as plt
 
 import utils


### PR DESCRIPTION
Some small bug fixes for the SegmentVesselsUsingNeuralNetworks example.

- Fix calls to `ShrinkImage` via `subprocess.call` by separating flags from their arguments.
- Change the `matplotlib` backend to avoid requiring TK
- Move the call to `caffe.set_mode_gpu()` up in `TrainNet.py` as Caffe currently requires (though undocumented) GPU mode to be set before creating a solver, else it crashes. 